### PR TITLE
Fix: cascade-delete gear items when a category is deleted

### DIFF
--- a/client/src/locales/de/common.json
+++ b/client/src/locales/de/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Element entfernen",
       "deleteCategoryTitle": "„{{title}}“ löschen?",
       "deleteCategoryTitleGeneric": "Diese Kategorie löschen?",
-      "deleteCategoryMessage": "Items in dieser Kategorie bleiben in deiner Liste, werden aber nach „Unsortiert“ verschoben.",
+      “deleteCategoryMessage”: “Die Kategorie und alle darin enthaltenen Items werden dauerhaft gelöscht.”,
       "deleteCategoryConfirm": "Kategorie löschen",
       "deleteListTitle": "„{{title}}“ löschen?",
       "deleteListMessage": "Damit wird diese Liste und alle enthaltenen Items dauerhaft gelöscht.",

--- a/client/src/locales/de/common.json
+++ b/client/src/locales/de/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Element entfernen",
       "deleteCategoryTitle": "„{{title}}“ löschen?",
       "deleteCategoryTitleGeneric": "Diese Kategorie löschen?",
-      “deleteCategoryMessage”: “Die Kategorie und alle darin enthaltenen Items werden dauerhaft gelöscht.”,
+      "deleteCategoryMessage": "Die Kategorie und alle darin enthaltenen Items werden dauerhaft gelöscht.",
       "deleteCategoryConfirm": "Kategorie löschen",
       "deleteListTitle": "„{{title}}“ löschen?",
       "deleteListMessage": "Damit wird diese Liste und alle enthaltenen Items dauerhaft gelöscht.",

--- a/client/src/locales/en/common.json
+++ b/client/src/locales/en/common.json
@@ -329,7 +329,7 @@
       "removeItemConfirm": "Remove item",
       "deleteCategoryTitle": "Delete “{{title}}”?",
       "deleteCategoryTitleGeneric": "Delete this category?",
-      "deleteCategoryMessage": "Items in this category will stay in your list but move to “Unsorted”.",
+      “deleteCategoryMessage”: “This will permanently delete the category and all items inside it.”,
       "deleteCategoryConfirm": "Delete category",
       "deleteListTitle": "Delete “{{title}}”?",
       "deleteListMessage": "This will permanently delete this list and all of its items.",

--- a/client/src/locales/en/common.json
+++ b/client/src/locales/en/common.json
@@ -329,7 +329,7 @@
       "removeItemConfirm": "Remove item",
       "deleteCategoryTitle": "Delete “{{title}}”?",
       "deleteCategoryTitleGeneric": "Delete this category?",
-      “deleteCategoryMessage”: “This will permanently delete the category and all items inside it.”,
+      "deleteCategoryMessage": "This will permanently delete the category and all items inside it.",
       "deleteCategoryConfirm": "Delete category",
       "deleteListTitle": "Delete “{{title}}”?",
       "deleteListMessage": "This will permanently delete this list and all of its items.",

--- a/client/src/locales/es/common.json
+++ b/client/src/locales/es/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Eliminar artículo",
       "deleteCategoryTitle": "¿Eliminar “{{title}}”?",
       "deleteCategoryTitleGeneric": "¿Eliminar esta categoría?",
-      “deleteCategoryMessage”: “Esto eliminará permanentemente la categoría y todos los artículos que contiene.”,
+      "deleteCategoryMessage": "Esto eliminará permanentemente la categoría y todos los artículos que contiene.",
       "deleteCategoryConfirm": "Eliminar categoría",
       "deleteListTitle": "¿Eliminar “{{title}}”?",
       "deleteListMessage": "Esto eliminará permanentemente esta lista y todos sus artículos.",

--- a/client/src/locales/es/common.json
+++ b/client/src/locales/es/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Eliminar artículo",
       "deleteCategoryTitle": "¿Eliminar “{{title}}”?",
       "deleteCategoryTitleGeneric": "¿Eliminar esta categoría?",
-      "deleteCategoryMessage": "Los artículos de esta categoría se quedarán en tu lista pero se moverán a “Sin clasificar”.",
+      “deleteCategoryMessage”: “Esto eliminará permanentemente la categoría y todos los artículos que contiene.”,
       "deleteCategoryConfirm": "Eliminar categoría",
       "deleteListTitle": "¿Eliminar “{{title}}”?",
       "deleteListMessage": "Esto eliminará permanentemente esta lista y todos sus artículos.",

--- a/client/src/locales/fr/common.json
+++ b/client/src/locales/fr/common.json
@@ -323,7 +323,7 @@
       "removeItemConfirm": "Supprimer l’article",
       "deleteCategoryTitle": "Supprimer « {{title}} » ?",
       "deleteCategoryTitleGeneric": "Supprimer cette catégorie ?",
-      "deleteCategoryMessage": "Les articles de cette catégorie resteront dans votre liste mais seront déplacés vers « Non triés ».",
+      "deleteCategoryMessage": "Cela supprimera définitivement la catégorie et tous les articles qu'elle contient.",
       "deleteCategoryConfirm": "Supprimer la catégorie",
       "deleteListTitle": "Supprimer « {{title}} » ?",
       "deleteListMessage": "Cela supprimera définitivement cette liste et tous ses articles.",

--- a/client/src/locales/it/common.json
+++ b/client/src/locales/it/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Rimuovi articolo",
       "deleteCategoryTitle": "Eliminare “{{title}}”?",
       "deleteCategoryTitleGeneric": "Eliminare questa categoria?",
-      "deleteCategoryMessage": "Gli articoli in questa categoria resteranno nella lista ma verranno spostati in “Non ordinati”.",
+      “deleteCategoryMessage”: “La categoria e tutti gli articoli al suo interno verranno eliminati definitivamente.”,
       "deleteCategoryConfirm": "Elimina categoria",
       "deleteListTitle": "Eliminare “{{title}}”?",
       "deleteListMessage": "Questa operazione eliminerà definitivamente la lista e tutti i suoi articoli.",

--- a/client/src/locales/it/common.json
+++ b/client/src/locales/it/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Rimuovi articolo",
       "deleteCategoryTitle": "Eliminare “{{title}}”?",
       "deleteCategoryTitleGeneric": "Eliminare questa categoria?",
-      “deleteCategoryMessage”: “La categoria e tutti gli articoli al suo interno verranno eliminati definitivamente.”,
+      "deleteCategoryMessage": "La categoria e tutti gli articoli al suo interno verranno eliminati definitivamente.",
       "deleteCategoryConfirm": "Elimina categoria",
       "deleteListTitle": "Eliminare “{{title}}”?",
       "deleteListMessage": "Questa operazione eliminerà definitivamente la lista e tutti i suoi articoli.",

--- a/client/src/locales/nl/common.json
+++ b/client/src/locales/nl/common.json
@@ -316,7 +316,7 @@
       "removeItemConfirm": "Item verwijderen",
       "deleteCategoryTitle": "‘{{title}}’ verwijderen?",
       "deleteCategoryTitleGeneric": "Deze categorie verwijderen?",
-      "deleteCategoryMessage": "Items in deze categorie blijven in je lijst maar worden verplaatst naar ‘Unsorted’.",
+      "deleteCategoryMessage": "Dit verwijdert de categorie en alle items erin permanent.",
       "deleteCategoryConfirm": "Categorie verwijderen",
       "deleteListTitle": "‘{{title}}’ verwijderen?",
       "deleteListMessage": "Hiermee verwijder je deze lijst en alle items daarin permanent.",

--- a/server/src/routes/categories.js
+++ b/server/src/routes/categories.js
@@ -2,6 +2,7 @@ const express = require("express");
 const auth = require("../middleware/auth");
 const GearList = require("../models/gearList");
 const Category = require("../models/category");
+const GearItem = require("../models/gearItem");
 
 const router = express.Router({ mergeParams: true });
 router.use(auth);
@@ -142,6 +143,8 @@ router.delete("/:catId", async (req, res) => {
     });
     if (!deleted)
       return res.status(404).json({ message: "Category not found." });
+
+    await GearItem.deleteMany({ gearList: listId, category: catId });
 
     res.json({ message: "Category deleted." });
   } catch (err) {


### PR DESCRIPTION
Items were silently orphaned (invisible but still counted in weight totals). Delete route now removes all GearItems in the category. Confirmation message updated across all locales to reflect permanent deletion.