### PR TITLE
Fix: render item detail modal in parent page for embedded lists

### DIFF
--- a/client/public/embed.js
+++ b/client/public/embed.js
@@ -38,6 +38,139 @@
     return `${origin}/share/${encodeURIComponent(cleanToken)}?embed=1`;
   }
 
+  // ── Parent-level modal overlay (escapes the iframe stacking context) ────────
+
+  var activeModalOverlay = null;
+  var activeModalIframe = null;
+
+  function gToOz(g) {
+    return typeof g === "number" ? g / 28.349523125 : null;
+  }
+
+  function fmtWeight(g, unit) {
+    if (g == null || isNaN(Number(g))) return "";
+    var n = Number(g);
+    if (unit === "oz") return (gToOz(n) || 0).toFixed(2) + " oz";
+    return Math.round(n) + " g";
+  }
+
+  function closeEmbedModal(sourceIframe) {
+    if (activeModalOverlay) {
+      activeModalOverlay.remove();
+      activeModalOverlay = null;
+    }
+    document.removeEventListener("keydown", handleModalKey);
+    // Notify the iframe that the modal was closed (so it can clear selectedItem)
+    var target = sourceIframe || activeModalIframe;
+    if (target && target.contentWindow) {
+      try {
+        target.contentWindow.postMessage({ type: "treklist:modal-closed" }, "*");
+      } catch (e) {}
+    }
+    activeModalIframe = null;
+  }
+
+  function handleModalKey(e) {
+    if (e.key === "Escape") closeEmbedModal(null);
+  }
+
+  function openEmbedModal(item, unit, sourceIframe) {
+    closeEmbedModal(null);
+
+    activeModalIframe = sourceIframe || null;
+
+    var safeImages = (Array.isArray(item.imageUrls) ? item.imageUrls : []).filter(function (u) {
+      return typeof u === "string" && u.trim() && /^https?:\/\//i.test(u.trim());
+    });
+    var hasImage = safeImages.length > 0;
+    var linkHref = (item.affiliate && (item.affiliate.deepLink || item.affiliate.url)) || item.link || null;
+    var linkLabel = (item.affiliate && item.affiliate.merchantName) || item.brand || "View product";
+
+    var rows = [
+      ["Type", item.itemType],
+      ["Name", item.name],
+      ["Brand", item.brand],
+      ["Weight", fmtWeight(Number(item.weight_g) || 0, unit)],
+      ["Quantity", String(item.qty != null ? item.qty : 1)],
+    ];
+    if (item.consumable) rows.push(["Consumable", "Yes"]);
+    if (item.worn) rows.push(["Worn", "Yes"]);
+
+    var rowsHtml = rows.map(function (r) {
+      var val = r[1] != null && r[1] !== "" ? r[1] : "—";
+      return '<div style="display:grid;grid-template-columns:130px 1fr;gap:8px;padding:4px 12px;">'
+        + '<div style="font-weight:600;color:#172b4d;">' + esc(r[0]) + ':</div>'
+        + '<div style="color:#172b4d;word-break:break-word;">' + esc(String(val)) + '</div>'
+        + '</div>';
+    }).join("");
+
+    var imgHtml = hasImage
+      ? '<div style="display:flex;align-items:center;justify-content:center;background:#fff;border:1px solid rgba(23,43,77,0.15);border-radius:6px;padding:8px;margin-bottom:16px;">'
+        + '<img src="' + esc(safeImages[0]) + '" alt="" style="max-height:240px;max-width:100%;object-fit:contain;" />'
+        + '</div>'
+      : "";
+
+    var descHtml = item.description
+      ? '<div style="margin-top:16px;padding:0 12px;">'
+        + '<div style="font-weight:600;color:#172b4d;margin-bottom:4px;">Description</div>'
+        + '<div style="color:#172b4d;white-space:pre-line;line-height:1.6;">' + esc(item.description) + '</div>'
+        + '</div>'
+      : "";
+
+    var linkHtml = linkHref
+      ? '<a href="' + esc(linkHref) + '" target="_blank" rel="noopener noreferrer"'
+        + ' style="display:inline-block;padding:6px 12px;background:#44546f;color:#fff;font-weight:600;border-radius:6px;text-decoration:none;">'
+        + esc(linkLabel) + '</a>'
+      : "";
+
+    var overlay = document.createElement("div");
+    overlay.setAttribute("id", "treklist-modal-overlay");
+    overlay.style.cssText = [
+      "position:fixed", "inset:0", "background:rgba(0,0,0,0.45)",
+      "display:flex", "align-items:center", "justify-content:center",
+      "z-index:2147483647", "padding:16px", "box-sizing:border-box",
+    ].join(";");
+
+    overlay.innerHTML =
+      '<div style="background:#fff;border-radius:8px;padding:24px;width:100%;max-width:' + (hasImage ? "800px" : "560px") + ';max-height:90vh;overflow-y:auto;box-shadow:0 25px 50px rgba(0,0,0,0.3);position:relative;box-sizing:border-box;font-family:system-ui,sans-serif;">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">'
+      + '<h2 style="margin:0;font-size:18px;font-weight:700;color:#172b4d;">Item Details</h2>'
+      + '<button id="treklist-modal-close" style="background:none;border:none;cursor:pointer;font-size:22px;line-height:1;color:#ef4444;padding:0 4px;" aria-label="Close">&times;</button>'
+      + '</div>'
+      + imgHtml
+      + rowsHtml
+      + descHtml
+      + '<div style="margin-top:16px;display:flex;justify-content:space-between;align-items:center;">'
+      + linkHtml
+      + '<button id="treklist-modal-close-btn" style="padding:6px 12px;background:#f1f2f4;border:none;border-radius:6px;cursor:pointer;font-size:14px;color:#172b4d;">Close</button>'
+      + '</div>'
+      + '</div>';
+
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) closeEmbedModal(sourceIframe);
+    });
+    overlay.querySelector("#treklist-modal-close").addEventListener("click", function () {
+      closeEmbedModal(sourceIframe);
+    });
+    overlay.querySelector("#treklist-modal-close-btn").addEventListener("click", function () {
+      closeEmbedModal(sourceIframe);
+    });
+
+    document.body.appendChild(overlay);
+    activeModalOverlay = overlay;
+    document.addEventListener("keydown", handleModalKey);
+  }
+
+  function esc(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+
   function ensureMessageListener() {
     if (state.listenerAttached) return;
     state.listenerAttached = true;
@@ -47,16 +180,29 @@
       if (!state.allowedOrigins.has(event.origin)) return;
 
       const msg = event && event.data;
-      if (!msg || msg.type !== "treklist:embed-height") return;
+      if (!msg) return;
 
-      const token = String(msg.token || "");
-      const iframe = state.iframesByToken[token];
-      if (!iframe) return;
+      if (msg.type === "treklist:embed-height") {
+        const token = String(msg.token || "");
+        const iframe = state.iframesByToken[token];
+        if (!iframe) return;
+        const h = Number(msg.height);
+        if (!Number.isFinite(h) || h < 100) return;
+        iframe.style.height = `${Math.ceil(h) + 2}px`;
+        return;
+      }
 
-      const h = Number(msg.height);
-      if (!Number.isFinite(h) || h < 100) return;
+      if (msg.type === "treklist:modal-open") {
+        const token = String(msg.token || "");
+        const iframe = state.iframesByToken[token] || null;
+        openEmbedModal(msg.item || {}, msg.unit || "g", iframe);
+        return;
+      }
 
-      iframe.style.height = `${Math.ceil(h) + 2}px`;
+      if (msg.type === "treklist:modal-close") {
+        closeEmbedModal(null);
+        return;
+      }
     });
   }
 

--- a/client/src/pages/PublicGearList.jsx
+++ b/client/src/pages/PublicGearList.jsx
@@ -251,6 +251,30 @@ export default function PublicGearList() {
     };
   }, [isEmbed, token, data, unit]);
 
+  // When embedded, delegate item modal to the parent page via postMessage
+  // (fixed positioning inside an iframe is relative to the iframe, not the screen).
+  React.useEffect(() => {
+    if (!isEmbed) return;
+    if (selectedItem) {
+      window.parent?.postMessage(
+        { type: "treklist:modal-open", token, item: selectedItem, unit },
+        "*",
+      );
+    } else {
+      window.parent?.postMessage({ type: "treklist:modal-close", token }, "*");
+    }
+  }, [isEmbed, selectedItem, token, unit]);
+
+  // Listen for close signal from parent (e.g. user clicks backdrop in parent overlay)
+  React.useEffect(() => {
+    if (!isEmbed) return;
+    const handler = (e) => {
+      if (e.data?.type === "treklist:modal-closed") setSelectedItem(null);
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [isEmbed]);
+
   // ---- Compute stats for PackStats (grams in, component handles display) ----
   function computeStatsPublic(items = []) {
     let baseWeight = 0;
@@ -942,7 +966,7 @@ export default function PublicGearList() {
         />
       )}
 
-      {selectedItem && (
+      {selectedItem && !isEmbed && (
         <PublicItemModal
           item={selectedItem}
           onClose={() => setSelectedItem(null)}


### PR DESCRIPTION
When a public list is embedded via iframe, position:fixed is relative to the iframe viewport rather than the screen. Fix by having the iframe postMessage the item data to the parent (embed.js), which renders the modal overlay directly in the parent document.