### PR TITLE
feat: add distinct page titles to all routes for GA and SEO

### DIFF
--- a/client/src/pages/AuthPage.jsx
+++ b/client/src/pages/AuthPage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import AuthModal from "../components/AuthModal";
+import SEO from "../components/SEO";
 
 const HERO_URL =
   "https://res.cloudinary.com/treklist/image/upload/c_fill,g_auto,f_auto,q_auto:eco,dpr_auto,w_1920/gear-list-hero-images/hero-hiker-cinque-torri_hpe3lz";
@@ -10,6 +11,7 @@ export default function AuthPage({ mode = "login" }) {
 
   return (
     <div className="relative min-h-screen">
+      <SEO title={mode === "register" ? "Create Account" : "Sign In"} noindex />
       <img
         src={HERO_URL}
         alt=""

--- a/client/src/pages/ChecklistView.jsx
+++ b/client/src/pages/ChecklistView.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import TopBar from "../components/TopBar"; // Standard TopBar integrated
+import TopBar from "../components/TopBar";
+import SEO from "../components/SEO";
 import { useUserSettings } from "../contexts/UserSettings";
 
 import { FaTshirt, FaUtensils } from "react-icons/fa";
@@ -197,7 +198,7 @@ export default function ChecklistView() {
 
   return (
     <div className="min-h-screen bg-neutral/50 text-primary print:bg-white">
-      {/* 1. NEW: Render the standard TopBar component */}
+      <SEO title={full.list?.title ? `${full.list.title} – Checklist` : "Checklist"} noindex />
       <TopBar title={t("app.name")} />
 
       <div className="border-b bg-base-100 print:hidden sticky top-[48px] z-50">

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ import { useUserSettings } from "../contexts/UserSettings";
 import { useTranslation } from "react-i18next";
 import Spinner from "../components/ui/Spinner";
 import TourModal from "../components/TourModal";
-import usePageTitle from "../hooks/usePageTitle";
+import SEO from "../components/SEO";
 import {
   DndContext,
   DragOverlay,
@@ -282,7 +282,14 @@ export default function Dashboard() {
     items: [],
   });
 
-  usePageTitle(fullData.list?.title ?? null);
+  const pageTitle = (() => {
+    if (activePane === "myGear") return "My Gear";
+    if (activePane === "templates") return "Templates";
+    if (activePane === "lists") return "My Lists";
+    if (activePane === "admin") return "Admin";
+    if (activePane === "wishlist") return "Wishlist";
+    return fullData.list?.title ?? "My Lists";
+  })();
 
   // ─── Lists state & fetchLists fn ───
   const [lists, setLists] = useState([]);
@@ -638,6 +645,7 @@ export default function Dashboard() {
 
   return (
     <div className="flex flex-col h-d-screen overflow-hidden bg-neutral/50 text-primary">
+      <SEO title={pageTitle} noindex />
       <TourModal
         isOpen={isTourOpen}
         stepIndex={tourStep}

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -29,7 +29,7 @@ export default function ForgotPassword() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <SEO title="Reset Password" noindex />
+      <SEO title="Forgot Password" noindex />
       <form
         onSubmit={handleSubmit}
         className="w-full max-w-md bg-white p-6 rounded shadow"

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -10,7 +10,6 @@ import AuthModal from "../components/AuthModal";
 import FooterLegal from "../components/FooterLegal";
 import PublicHeader from "../components/PublicHeader";
 import SEO from "../components/SEO";
-import usePageTitle from "../hooks/usePageTitle";
 
 // helper to build share path safely
 const sharePath = (token) => (token ? `/share/${token}/` : null);
@@ -107,7 +106,6 @@ const Bullet = ({ title, text, color = "text-blue-600" }) => (
 
 export default function Landing() {
   const { t } = useTranslation("common");
-  usePageTitle(t("landing.pageTitle"));
 
   // Preload hero for faster first paint
   useEffect(() => {

--- a/client/src/pages/legal/CookieSettings.jsx
+++ b/client/src/pages/legal/CookieSettings.jsx
@@ -1,13 +1,12 @@
 import React from "react";
 import LegalLayout from "../../components/LegalLayout";
 import CookieSettingsContent from "../../components/legal/CookieSettingsContent";
-import usePageTitle from "../../hooks/usePageTitle";
+import SEO from "../../components/SEO";
 
 export default function CookieSettingsPage() {
-  usePageTitle("Cookie Settings");
-
   return (
     <LegalLayout>
+      <SEO title="Cookie Settings" noindex />
       <CookieSettingsContent />
     </LegalLayout>
   );


### PR DESCRIPTION
Every routed page now sets a meaningful document.title via the SEO component (react-helmet-async), replacing the patchwork of usePageTitle calls and pages with no title at all. Dashboard title is dynamic based on active pane (My Gear, Templates, My Lists, list name).