### PR TITLE
fix: only clear session on auth errors, not network/server failures

### DIFF
--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -49,9 +49,13 @@ export function AuthProvider({ children }) {
         })
         .catch((err) => {
           console.error("Failed to fetch current user:", err);
-          clearGlobalItemCache();
-          setUser(null);
-          setToken(null);
+          const status = err?.response?.status;
+          if (status === 401 || status === 403) {
+            clearGlobalItemCache();
+            setUser(null);
+            setToken(null);
+          }
+          // Network errors / 5xx: keep the token so the user stays logged in
         });
     } else {
       setUser(null);


### PR DESCRIPTION
Previously any error from the startup /auth/me check (network timeout, 5xx, server cold-start) would wipe the access token from localStorage, forcing the user to log in again on every visit. Now only 401/403 responses clear the session.