### PR TITLE
fix: sort admin users and public lists across full dataset, not just …

### DIFF
--- a/client/src/pages/AdminView.jsx
+++ b/client/src/pages/AdminView.jsx
@@ -3566,12 +3566,14 @@ function UsersSection() {
     searchOverride,
     roleOverride,
     verifiedOverride,
+    sortOverride,
   } = {}) => {
     const nextPage = pageOverride ?? page;
     const nextPageSize = pageSizeOverride ?? pageSize;
     const nextSearch = searchOverride ?? search;
     const nextRole = roleOverride ?? roleFilter;
     const nextVerified = verifiedOverride ?? verifiedFilter;
+    const nextSort = sortOverride ?? sort;
 
     setLoading(true);
     setError("");
@@ -3579,6 +3581,8 @@ function UsersSection() {
       const params = {
         limit: nextPageSize,
         skip: nextPage * nextPageSize,
+        sortField: nextSort.field,
+        sortDir: nextSort.dir,
       };
 
       if (nextSearch.trim()) params.q = nextSearch.trim();
@@ -3606,18 +3610,12 @@ function UsersSection() {
   }, []);
 
   const handleSort = (field) => {
-    setSort((prev) => {
-      if (prev.field === field) {
-        return {
-          field,
-          dir: prev.dir === "asc" ? "desc" : "asc",
-        };
-      }
-      return {
-        field,
-        dir: "asc",
-      };
-    });
+    const newSort =
+      sort.field === field
+        ? { field, dir: sort.dir === "asc" ? "desc" : "asc" }
+        : { field, dir: "asc" };
+    setSort(newSort);
+    loadUsers({ pageOverride: 0, sortOverride: newSort });
   };
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -3881,8 +3879,9 @@ function UsersSection() {
                     className="select select-xs select-bordered flex-1"
                     value={sort.field}
                     onChange={(e) => {
-                      const f = e.target.value;
-                      setSort({ field: f, dir: "asc" });
+                      const newSort = { field: e.target.value, dir: "asc" };
+                      setSort(newSort);
+                      loadUsers({ pageOverride: 0, sortOverride: newSort });
                     }}
                   >
                     <option value="createdAt">Sort: Created</option>
@@ -3899,12 +3898,11 @@ function UsersSection() {
                   <button
                     type="button"
                     className="btn btn-ghost btn-xs"
-                    onClick={() =>
-                      setSort((prev) => ({
-                        ...prev,
-                        dir: prev.dir === "asc" ? "desc" : "asc",
-                      }))
-                    }
+                    onClick={() => {
+                      const newSort = { ...sort, dir: sort.dir === "asc" ? "desc" : "asc" };
+                      setSort(newSort);
+                      loadUsers({ pageOverride: 0, sortOverride: newSort });
+                    }}
                     title={sort.dir === "asc" ? "Ascending" : "Descending"}
                   >
                     {sort.dir === "asc" ? "↑" : "↓"}
@@ -4313,10 +4311,12 @@ function PublicListsSection() {
     pageOverride,
     pageSizeOverride,
     searchOverride,
+    sortOverride,
   } = {}) => {
     const nextPage = pageOverride ?? page;
     const nextPageSize = pageSizeOverride ?? pageSize;
     const nextSearch = searchOverride ?? search;
+    const nextSort = sortOverride ?? sort;
 
     setLoading(true);
     setError("");
@@ -4324,6 +4324,8 @@ function PublicListsSection() {
       const params = {
         limit: nextPageSize,
         skip: nextPage * nextPageSize,
+        sortField: nextSort.field,
+        sortDir: nextSort.dir,
       };
       if (nextSearch.trim()) {
         params.q = nextSearch.trim();
@@ -4351,18 +4353,12 @@ function PublicListsSection() {
   }, []);
 
   const handleSort = (field) => {
-    setSort((prev) => {
-      if (prev.field === field) {
-        return {
-          field,
-          dir: prev.dir === "asc" ? "desc" : "asc",
-        };
-      }
-      return {
-        field,
-        dir: "asc",
-      };
-    });
+    const newSort =
+      sort.field === field
+        ? { field, dir: sort.dir === "asc" ? "desc" : "asc" }
+        : { field, dir: "asc" };
+    setSort(newSort);
+    loadLists({ pageOverride: 0, sortOverride: newSort });
   };
 
   const boolToNum = (val) => (val ? 1 : 0);
@@ -4652,8 +4648,9 @@ function PublicListsSection() {
                     className="select select-xs select-bordered flex-1"
                     value={sort.field}
                     onChange={(e) => {
-                      const f = e.target.value;
-                      setSort({ field: f, dir: "asc" });
+                      const newSort = { field: e.target.value, dir: "asc" };
+                      setSort(newSort);
+                      loadLists({ pageOverride: 0, sortOverride: newSort });
                     }}
                   >
                     <option value="createdAt">Sort: Created</option>
@@ -4665,12 +4662,11 @@ function PublicListsSection() {
                   <button
                     type="button"
                     className="btn btn-ghost btn-xs"
-                    onClick={() =>
-                      setSort((prev) => ({
-                        ...prev,
-                        dir: prev.dir === "asc" ? "desc" : "asc",
-                      }))
-                    }
+                    onClick={() => {
+                      const newSort = { ...sort, dir: sort.dir === "asc" ? "desc" : "asc" };
+                      setSort(newSort);
+                      loadLists({ pageOverride: 0, sortOverride: newSort });
+                    }}
                     title={sort.dir === "asc" ? "Ascending" : "Descending"}
                   >
                     {sort.dir === "asc" ? "↑" : "↓"}

--- a/server/src/routes/adminPublicLists.js
+++ b/server/src/routes/adminPublicLists.js
@@ -16,6 +16,8 @@ const router = express.Router();
  *   - limit (default 25, max 100)
  *   - skip (default 0)
  *   - q: optional search on list title, user email/trailname, or token
+ *   - sortField: "title" | "owner" | "views" | "lastViewedAt" | "createdAt" (default "createdAt")
+ *   - sortDir: "asc" | "desc" (default "desc")
  */
 router.get("/", async (req, res) => {
   try {
@@ -28,6 +30,8 @@ router.get("/", async (req, res) => {
     const skip = Number.isFinite(rawSkip) ? Math.max(rawSkip, 0) : 0;
 
     const q = (req.query.q || "").trim().toLowerCase();
+    const sortField = req.query.sortField || "createdAt";
+    const sortDir = req.query.sortDir === "asc" ? 1 : -1;
 
     // Volume of public lists is expected to be small, so we can do
     // in-memory filtering + pagination for now.
@@ -64,6 +68,37 @@ router.get("/", async (req, res) => {
         );
       });
     }
+
+    rows.sort((a, b) => {
+      switch (sortField) {
+        case "title": {
+          const at = (a.list.title || "").toLowerCase();
+          const bt = (b.list.title || "").toLowerCase();
+          return at.localeCompare(bt) * sortDir;
+        }
+        case "owner": {
+          const ae = (a.owner.email || "").toLowerCase();
+          const be = (b.owner.email || "").toLowerCase();
+          return ae.localeCompare(be) * sortDir;
+        }
+        case "views": {
+          const av = a.viewsCount ?? 0;
+          const bv = b.viewsCount ?? 0;
+          return (av - bv) * sortDir;
+        }
+        case "lastViewedAt": {
+          const al = a.lastViewedAt ? new Date(a.lastViewedAt).getTime() : 0;
+          const bl = b.lastViewedAt ? new Date(b.lastViewedAt).getTime() : 0;
+          return (al - bl) * sortDir;
+        }
+        case "createdAt":
+        default: {
+          const ac = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+          const bc = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+          return (ac - bc) * sortDir;
+        }
+      }
+    });
 
     const total = rows.length;
     const pageRows = rows.slice(skip, skip + limit);

--- a/server/src/routes/adminUsers.js
+++ b/server/src/routes/adminUsers.js
@@ -24,9 +24,21 @@ function escapeRegex(s) {
 // All routes below require auth + admin
 router.use(auth, requireAdmin);
 
+const USER_SORT_FIELD_MAP = {
+  email: "email",
+  trailname: "trailname",
+  role: "isAdmin",
+  verified: "isVerified",
+  marketing: "marketing.optedIn",
+  createdAt: "createdAt",
+  updatedAt: "updatedAt",
+  lastLoginAt: "lastLoginAt",
+  lastActiveAt: "lastActiveAt",
+};
+
 /**
  * GET /api/admin/users
- * List users with search, filters, pagination, and listsCount
+ * List users with search, filters, pagination, sorting, and listsCount
  *
  * Query params:
  *  - q           (optional) search term (email / trailname)
@@ -34,6 +46,8 @@ router.use(auth, requireAdmin);
  *  - role        (optional) "admin" | "user"
  *  - limit       (optional) default 50, max 200
  *  - skip        (optional) default 0
+ *  - sortField   (optional) field to sort by (see USER_SORT_FIELD_MAP)
+ *  - sortDir     (optional) "asc" | "desc" (default "desc")
  */
 router.get("/", async (req, res) => {
   try {
@@ -43,6 +57,8 @@ router.get("/", async (req, res) => {
       role = "all",
       limit = 50,
       skip = 0,
+      sortField = "createdAt",
+      sortDir = "desc",
     } = req.query;
 
     const query = {};
@@ -64,10 +80,13 @@ router.get("/", async (req, res) => {
     const safeLimit = Math.min(Number(limit) || 50, 200);
     const safeSkip = Number(skip) || 0;
 
+    const dbSortField = USER_SORT_FIELD_MAP[sortField] || "createdAt";
+    const dbSortDir = sortDir === "asc" ? 1 : -1;
+
     // Fetch users (lean for speed, project only needed fields)
     const [users, total] = await Promise.all([
       User.find(query)
-        .sort({ createdAt: -1 })
+        .sort({ [dbSortField]: dbSortDir })
         .skip(safeSkip)
         .limit(safeLimit)
         .select(


### PR DESCRIPTION
…current page

Sorting now triggers a server-side reload from page 0, so column sorts apply to the entire dataset rather than just the 25 records in memory.