### PR TITLE
feat: integrate Kit email subscription on marketing opt-in

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -10,6 +10,7 @@ const User = require("../models/user");
 // ✅ Reuse shared mailer (single source of truth)
 // Adjust the path if your mailer lives elsewhere.
 const { sendSupportEmail } = require("../utils/mailer");
+const { subscribeToKit } = require("../utils/kitSubscribe");
 
 const router = express.Router();
 router.use(cookieParser());
@@ -431,6 +432,10 @@ router.post("/verify-email", async (req, res) => {
   user.isVerified = true;
   user.verifyEmailToken = undefined;
   user.verifyEmailExpires = undefined;
+
+  if (user.marketing?.optedIn) {
+    subscribeToKit(user.email, user.trailname || '');
+  }
 
   const tokens = issueTokens(user);
 

--- a/server/src/routes/settings.js
+++ b/server/src/routes/settings.js
@@ -3,6 +3,7 @@ const express = require("express");
 const router = express.Router();
 const User = require("../models/user");
 const { authenticate } = require("./auth"); // import your JWT middleware
+const { subscribeToKit } = require("../utils/kitSubscribe");
 
 // All /settings routes require a valid Bearer token
 router.use(authenticate);
@@ -119,6 +120,7 @@ router.patch("/", async (req, res) => {
         user.marketing.optedInSource = ["settings", "banner"].includes(src)
           ? src
           : "settings";
+        subscribeToKit(user.email, user.trailname || '');
       } else if (!nextOptIn && prevOptIn) {
         // user is opting out
         user.marketing.optedIn = false;

--- a/server/src/utils/kitSubscribe.js
+++ b/server/src/utils/kitSubscribe.js
@@ -1,0 +1,54 @@
+const KIT_API_KEY = process.env.KIT_API_KEY;
+const KIT_API_BASE = 'https://api.kit.com/v4';
+const KIT_TREKLIST_TAG_ID = 19523737;
+
+const KIT_HEADERS = () => ({
+  'Content-Type': 'application/json',
+  'X-Kit-Api-Key': KIT_API_KEY,
+});
+
+async function subscribeToKit(email, firstName = '') {
+  if (!KIT_API_KEY) {
+    console.warn('[Kit] KIT_API_KEY not set — skipping subscription.');
+    return;
+  }
+
+  try {
+    // Step 1: create/update subscriber
+    const subRes = await fetch(`${KIT_API_BASE}/subscribers`, {
+      method: 'POST',
+      headers: KIT_HEADERS(),
+      body: JSON.stringify({
+        email_address: email,
+        first_name: firstName || '',
+        state: 'active',
+      }),
+    });
+
+    if (!subRes.ok) {
+      const error = await subRes.json().catch(() => ({}));
+      console.error('[Kit] Failed to create subscriber:', error);
+      return;
+    }
+
+    const { subscriber } = await subRes.json();
+
+    // Step 2: apply TrekList tag
+    const tagRes = await fetch(`${KIT_API_BASE}/tags/${KIT_TREKLIST_TAG_ID}/subscribers`, {
+      method: 'POST',
+      headers: KIT_HEADERS(),
+      body: JSON.stringify({ email_address: email }),
+    });
+
+    if (!tagRes.ok) {
+      const error = await tagRes.json().catch(() => ({}));
+      console.error('[Kit] Failed to apply tag:', error);
+    } else {
+      console.log(`[Kit] Subscribed and tagged: ${email} (id: ${subscriber?.id})`);
+    }
+  } catch (err) {
+    console.error('[Kit] Subscription error:', err.message);
+  }
+}
+
+module.exports = { subscribeToKit };


### PR DESCRIPTION
Subscribers are added to Kit (tagged TrekList) at two points:
- Email signup: on email verification if marketing was checked at registration
- Settings/banner: when a user transitions from opted-out to opted-in