### PR TITLE
feat: expand Women's Clothing subcategories to match Men's

### DIFF
--- a/client/src/config/catalogTaxonomy.js
+++ b/client/src/config/catalogTaxonomy.js
@@ -105,7 +105,18 @@ export const CATALOG_SUBCATEGORIES = {
   ],
   Travel: ["Documents", "Personal Care", "Towels", "Wallet"],
   "Unisex Clothing": ["Accessories", "Headwear", "Neck Gaiter", "Rain Gear"],
-  "Women's Clothing": ["Base Layers", "Jackets", "Socks"],
+  "Women's Clothing": [
+    "Base Layers",
+    "Hands",
+    "Jackets",
+    "Long-Sleeved T-Shirt",
+    "Pants",
+    "Rain Gear",
+    "Shirts",
+    "Shorts",
+    "Socks",
+    "Underwear",
+  ],
 };
 
 // UI helper: translate a canonical subcategory value

--- a/client/src/locales/de/common.json
+++ b/client/src/locales/de/common.json
@@ -827,6 +827,7 @@
       "Quilts": "Quilts",
       "Rain Gear": "Regenkleidung",
       "Shirts": "Shirts",
+      "Shorts": "Shorts",
       "Sleeping Bag Accessories": "Schlafsack-Zubehör",
       "Sleeping Bag Liners": "Schlafsack-Inlets",
       "Sleeping Bags": "Schlafsäcke",

--- a/client/src/locales/en/common.json
+++ b/client/src/locales/en/common.json
@@ -843,6 +843,7 @@
       "Quilts": "Quilts",
       "Rain Gear": "Rain Gear",
       "Shirts": "Shirts",
+      "Shorts": "Shorts",
       "Sleeping Bag Accessories": "Sleeping Bag Accessories",
       "Sleeping Bag Liners": "Sleeping Bag Liners",
       "Sleeping Bags": "Sleeping Bags",

--- a/client/src/locales/es/common.json
+++ b/client/src/locales/es/common.json
@@ -827,6 +827,7 @@
       "Quilts": "Quilts",
       "Rain Gear": "Ropa de lluvia",
       "Shirts": "Camisas",
+      "Shorts": "Pantalones cortos",
       "Sleeping Bag Accessories": "Accesorios saco de dormir",
       "Sleeping Bag Liners": "Fundas saco de dormir",
       "Sleeping Bags": "Sacos de dormir",

--- a/client/src/locales/fr/common.json
+++ b/client/src/locales/fr/common.json
@@ -834,6 +834,7 @@
       "Quilts": "Couettes",
       "Rain Gear": "Vêtements imperméables",
       "Shirts": "Chemises",
+      "Shorts": "Shorts",
       "Sleeping Bag Accessories": "Accessoires sac de couchage",
       "Sleeping Bag Liners": "Draps de sac de couchage",
       "Sleeping Bags": "Sacs de couchage",

--- a/client/src/locales/it/common.json
+++ b/client/src/locales/it/common.json
@@ -827,6 +827,7 @@
       "Quilts": "Quilt",
       "Rain Gear": "Abbigliamento antipioggia",
       "Shirts": "Maglie",
+      "Shorts": "Pantaloncini",
       "Sleeping Bag Accessories": "Accessori sacco a pelo",
       "Sleeping Bag Liners": "Fodere sacco a pelo",
       "Sleeping Bags": "Sacchi a pelo",

--- a/client/src/locales/nl/common.json
+++ b/client/src/locales/nl/common.json
@@ -827,6 +827,7 @@
       "Quilts": "Quilts",
       "Rain Gear": "Regenkleding",
       "Shirts": "Shirts",
+      "Shorts": "Shorts",
       "Sleeping Bag Accessories": "Slaapzakaccesoires",
       "Sleeping Bag Liners": "Slaapzakinleggers",
       "Sleeping Bags": "Slaapzakken",


### PR DESCRIPTION
Adds Hands, Long-Sleeved T-Shirt, Pants, Rain Gear, Shirts, Shorts, and Underwear to Women's Clothing. Also adds missing 'Shorts' translation key across all 6 locales (en/fr/de/it/nl/es).