### PR TITLE
feat: start tour for new users arriving via share-link copy+signup

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -426,6 +426,23 @@ export default function Dashboard() {
     localStorage.setItem("lastListId", listId);
   }, [listId]);
 
+  // ─── Start tour for users who arrive via share-link copy+signup ───
+  const fromShareCopy = location.state?.fromShareCopy ?? false;
+  const copyTourStartedRef = useRef(false);
+  useEffect(() => {
+    if (!fromShareCopy) return;
+    if (!user) return;
+    if (hasSeenTour) return;
+    if (!listId) return;
+    if (copyTourStartedRef.current) return;
+    copyTourStartedRef.current = true;
+    const timer = setTimeout(() => {
+      setTourStep(0);
+      setIsTourOpen(true);
+    }, 350);
+    return () => clearTimeout(timer);
+  }, [listId, fromShareCopy, user, hasSeenTour]);
+
   // ─── Redirect logic ───
   useEffect(() => {
     if (!isAuthenticated) return;

--- a/client/src/pages/PublicGearList.jsx
+++ b/client/src/pages/PublicGearList.jsx
@@ -164,7 +164,7 @@ export default function PublicGearList() {
       ); // success → go to new list
       const newId = resp.listId || resp.list?._id;
       if (newId) {
-        navigate(`/dashboard/${newId}`, { replace: true });
+        navigate(`/dashboard/${newId}`, { replace: true, state: { fromShareCopy: true } });
       } else {
         // Safety net: if API shape changes
         window.location.href = "/dashboard";
@@ -181,7 +181,7 @@ export default function PublicGearList() {
           );
           const newId2 = retry.listId || retry.list?._id;
           if (newId2) {
-            navigate(`/dashboard/${newId2}`, { replace: true });
+            navigate(`/dashboard/${newId2}`, { replace: true, state: { fromShareCopy: true } });
             return;
           }
         } catch {


### PR DESCRIPTION
After a user creates an account through the "Customize this list" flow and lands on their copied list, Dashboard now detects the fromShareCopy navigation state and auto-starts the tour if they haven't seen it yet.