### PR TITLE
fix: preserve next URL through Google OAuth flow for share-link copy

### DIFF
--- a/client/src/components/AuthModal.jsx
+++ b/client/src/components/AuthModal.jsx
@@ -234,6 +234,9 @@ export default function AuthModal({
 
   const handleGoogleLogin = () => {
     const apiUrl = import.meta.env.VITE_API_URL || "";
+    if (next) {
+      localStorage.setItem("oauthNext", next);
+    }
     window.location.href = `${apiUrl}/api/auth/google`;
   };
 

--- a/client/src/pages/AuthCallback.jsx
+++ b/client/src/pages/AuthCallback.jsx
@@ -34,7 +34,11 @@ export default function AuthCallback() {
       .then(({ data }) => {
         localStorage.setItem("accessToken", data.accessToken);
         hydrateFromStorage();
-        navigate("/dashboard", { replace: true });
+        const oauthNext = localStorage.getItem("oauthNext");
+        localStorage.removeItem("oauthNext");
+        const safeNext =
+          oauthNext && oauthNext.startsWith("/") ? oauthNext : null;
+        navigate(safeNext || "/dashboard", { replace: true });
       })
       .catch(() => {
         navigate("/?authError=token_exchange_failed", { replace: true });


### PR DESCRIPTION
handleGoogleLogin was discarding the ?next param before redirecting to Google. After OAuth, AuthCallback always navigated to /dashboard, so the share copy was never triggered for users who signed up via Google.

Store next in localStorage before the OAuth redirect and restore it in AuthCallback after the token exchange.