### PR TITLE
fix: skip trailname confirmation prompt for email-registered users

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -374,6 +374,7 @@ router.post("/register", registerLimiter, async (req, res) => {
     const user = new User({
       email: normalizedEmail,
       trailname: trimmedTrailname,
+      trailnameConfirmed: !!trimmedTrailname,
       isVerified: false,
       authProviders: [
         {


### PR DESCRIPTION
Users who provide a trailname during registration have already consciously chosen it. Setting trailnameConfirmed: true at signup prevents the redundant confirmation prompt from appearing immediately after they log in.