### PR TITLE
feat: 24h welcome email with auto-unsubscribe

### DIFF
--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -119,6 +119,8 @@ export default function Landing() {
   const location = useLocation();
   const navigate = useNavigate();
 
+  const [showUnsubscribedBanner, setShowUnsubscribedBanner] = useState(false);
+
   // auto-open modal when arriving with a ?next= param (share → auth flow).
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -127,6 +129,11 @@ export default function Landing() {
     if (hasNext && !authOpen) {
       setAuthMode("register");
       setAuthOpen(true);
+    }
+
+    if (params.get("unsubscribed") === "1") {
+      setShowUnsubscribedBanner(true);
+      navigate("/", { replace: true });
     }
   }, [location.pathname, location.search]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -211,6 +218,18 @@ export default function Landing() {
           }
         })}</script>
       </SEO>
+      {showUnsubscribedBanner && (
+        <div className="relative z-50 bg-green-50 border-b border-green-200 px-4 py-3 flex items-center justify-between gap-4">
+          <p className="text-sm text-green-800">You've been unsubscribed from TrekList emails.</p>
+          <button
+            onClick={() => setShowUnsubscribedBanner(false)}
+            className="text-green-700 hover:text-green-900 text-lg leading-none"
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      )}
       <PublicHeader
         variant="overlay"
         showSections={true}

--- a/server/src/jobs/welcomeEmailJob.js
+++ b/server/src/jobs/welcomeEmailJob.js
@@ -1,0 +1,83 @@
+const crypto = require("crypto");
+const User = require("../models/user");
+const GearList = require("../models/gearList");
+const { sendWelcomeEmail } = require("../utils/mailer");
+
+const WINDOW_MIN_MS = 23 * 60 * 60 * 1000; // 23h
+const WINDOW_MAX_MS = 25 * 60 * 60 * 1000; // 25h
+const INTERVAL_MS   = 60 * 60 * 1000;       // run every hour
+
+function buildUnsubscribeUrl(userId) {
+  const uid = userId.toString();
+  const sig = crypto
+    .createHmac("sha256", process.env.JWT_SECRET)
+    .update(uid)
+    .digest("hex")
+    .slice(0, 32);
+  const base = (process.env.CLIENT_URL || process.env.CLIENT_URLS || "").split(",")[0].trim();
+  return `${base}/unsubscribe-onboarding?uid=${uid}&sig=${sig}`;
+}
+
+async function runWelcomeEmailJob() {
+  const now = Date.now();
+  const windowStart = new Date(now - WINDOW_MAX_MS);
+  const windowEnd   = new Date(now - WINDOW_MIN_MS);
+
+  let candidates;
+  try {
+    candidates = await User.find({
+      createdAt: { $gte: windowStart, $lte: windowEnd },
+      isVerified: true,
+      "onboarding.welcomeEmailSentAt": null,
+      "onboarding.transactionalOptOut": { $ne: true },
+    }).select("_id email trailname createdAt");
+  } catch (err) {
+    console.error("[welcomeEmailJob] DB query failed:", err.message);
+    return;
+  }
+
+  if (!candidates.length) return;
+
+  console.log(`[welcomeEmailJob] ${candidates.length} candidate(s) found`);
+
+  for (const user of candidates) {
+    try {
+      // Find their most recent list to deep-link into
+      const list = await GearList.findOne({ owner: user._id })
+        .sort({ createdAt: -1 })
+        .select("_id");
+
+      const base = (process.env.CLIENT_URL || process.env.CLIENT_URLS || "").split(",")[0].trim();
+      const listUrl = list
+        ? `${base}/dashboard/${list._id}`
+        : `${base}/dashboard`;
+
+      const unsubscribeUrl = buildUnsubscribeUrl(user._id);
+
+      await sendWelcomeEmail({
+        to: user.email,
+        trailname: user.trailname,
+        listUrl,
+        unsubscribeUrl,
+      });
+
+      await User.updateOne(
+        { _id: user._id },
+        { $set: { "onboarding.welcomeEmailSentAt": new Date() } }
+      );
+
+      console.log(`[welcomeEmailJob] Sent to ${user.email}`);
+    } catch (err) {
+      console.error(`[welcomeEmailJob] Failed for ${user.email}:`, err.message);
+      // Continue to next user — don't let one failure block the rest
+    }
+  }
+}
+
+function startWelcomeEmailJob() {
+  console.log("[welcomeEmailJob] Scheduler started (runs every hour)");
+  runWelcomeEmailJob();
+  setInterval(runWelcomeEmailJob, INTERVAL_MS);
+}
+
+module.exports = { startWelcomeEmailJob, buildUnsubscribeUrl };

--- a/server/src/models/user.js
+++ b/server/src/models/user.js
@@ -28,6 +28,8 @@ const UserSchema = new mongoose.Schema(
     onboarding: {
       tourVersionSeen: { type: Number, default: 0 },
       tourDismissedAt: { type: Date, default: null },
+      welcomeEmailSentAt: { type: Date, default: null },
+      transactionalOptOut: { type: Boolean, default: false },
     },
     // If true, this account is blocked from logging in
     isDisabled: {

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -10,7 +10,7 @@ const User = require("../models/user");
 // ✅ Reuse shared mailer (single source of truth)
 // Adjust the path if your mailer lives elsewhere.
 const { sendSupportEmail } = require("../utils/mailer");
-const { subscribeToKit } = require("../utils/kitSubscribe");
+const { subscribeToKit, unsubscribeFromKit } = require("../utils/kitSubscribe");
 
 const router = express.Router();
 router.use(cookieParser());
@@ -694,6 +694,50 @@ router.post("/exchange", oauthLimiter, async (req, res) => {
     console.error("POST /auth/exchange error:", err);
     res.status(500).json({ message: "Token exchange failed." });
   }
+});
+
+// GET /auth/unsubscribe-onboarding?uid=...&sig=...
+// One-click unsubscribe for transactional onboarding emails (no login required)
+router.get("/unsubscribe-onboarding", async (req, res) => {
+  const { uid, sig } = req.query;
+  if (!uid || !sig) {
+    return res.status(400).send("Invalid unsubscribe link.");
+  }
+
+  const expected = crypto
+    .createHmac("sha256", process.env.JWT_SECRET)
+    .update(uid)
+    .digest("hex")
+    .slice(0, 32);
+
+  if (sig !== expected) {
+    return res.status(400).send("Invalid unsubscribe link.");
+  }
+
+  let userEmail;
+  try {
+    const user = await User.findByIdAndUpdate(
+      uid,
+      {
+        $set: {
+          "onboarding.transactionalOptOut": true,
+          "marketing.optedIn": false,
+        },
+      },
+      { new: false, select: "email" }
+    );
+    userEmail = user?.email;
+  } catch {
+    return res.status(500).send("Something went wrong. Please try again.");
+  }
+
+  if (userEmail) {
+    unsubscribeFromKit(userEmail).catch(() => {}); // fire-and-forget
+  }
+
+  // Redirect to the client with a confirmation flag
+  const base = (process.env.CLIENT_URL || process.env.CLIENT_URLS || "").split(",")[0].trim();
+  return res.redirect(`${base}/?unsubscribed=1`);
 });
 
 router.authenticate = authenticate;

--- a/server/src/scripts/send-welcome-email-backfill.js
+++ b/server/src/scripts/send-welcome-email-backfill.js
@@ -1,0 +1,93 @@
+// server/src/scripts/send-welcome-email-backfill.js
+// =============================================================================
+// ONE-TIME BACKFILL: Send welcome email to recent users who never received one
+// =============================================================================
+//
+// WHAT THIS DOES:
+//   Finds verified users created in the last 30 days who have not yet received
+//   a welcome email, and sends them the standard welcome email.
+//   Marks each user with welcomeEmailSentAt after sending.
+//
+// RUN:
+//   cd server
+//   node src/scripts/send-welcome-email-backfill.js
+//
+// OPTIONS:
+//   --dry-run     Preview who would be emailed without sending anything
+//
+// =============================================================================
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+
+const User = require("../models/user");
+const GearList = require("../models/gearList");
+const { sendWelcomeEmail } = require("../utils/mailer");
+const { buildUnsubscribeUrl } = require("../jobs/welcomeEmailJob");
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI, {
+    dbName: process.env.MONGO_DB_NAME,
+  });
+  console.log(`Connected to MongoDB (db=${mongoose.connection.name}`);
+
+  if (DRY_RUN) console.log("DRY RUN — no emails will be sent\n");
+
+  const since = new Date(Date.now() - THIRTY_DAYS_MS);
+
+  const candidates = await User.find({
+    createdAt: { $gte: since },
+    isVerified: true,
+    "onboarding.welcomeEmailSentAt": null,
+    "onboarding.transactionalOptOut": { $ne: true },
+    email: { $not: /@treklist\.(co|dev)$/i },
+  }).select("_id email trailname createdAt");
+
+  console.log(`Found ${candidates.length} candidate(s)\n`);
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const user of candidates) {
+    const list = await GearList.findOne({ owner: user._id })
+      .sort({ createdAt: -1 })
+      .select("_id");
+
+    const base = (process.env.CLIENT_URL || process.env.CLIENT_URLS || "").split(",")[0].trim();
+    const listUrl = list ? `${base}/dashboard/${list._id}` : `${base}/dashboard`;
+    const unsubscribeUrl = buildUnsubscribeUrl(user._id);
+
+    const signedUpDaysAgo = Math.round((Date.now() - new Date(user.createdAt)) / (1000 * 60 * 60 * 24));
+
+    console.log(`  ${user.email} (${user.trailname || "no trail name"}, signed up ${signedUpDaysAgo}d ago)`);
+    console.log(`    → list: ${listUrl}`);
+
+    if (DRY_RUN) continue;
+
+    try {
+      await sendWelcomeEmail({ to: user.email, trailname: user.trailname, listUrl, unsubscribeUrl });
+      await User.updateOne(
+        { _id: user._id },
+        { $set: { "onboarding.welcomeEmailSentAt": new Date() } }
+      );
+      console.log(`    ✓ Sent`);
+      sent++;
+    } catch (err) {
+      console.error(`    ✗ Failed: ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log(`\nDone. Sent: ${sent}  Failed: ${failed}`);
+  await mongoose.disconnect();
+}
+
+run().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -8,9 +8,11 @@ console.log(
 
 const app = require("./app");
 const mongoose = require("mongoose");
+const { startWelcomeEmailJob } = require("./jobs/welcomeEmailJob");
 
 const PORT = process.env.PORT || 5001;
 
 app.listen(PORT, () => {
   console.log(`🚀 Server running on ${PORT}`);
+  startWelcomeEmailJob();
 });

--- a/server/src/utils/mailer.js
+++ b/server/src/utils/mailer.js
@@ -1,4 +1,5 @@
 const nodemailer = require("nodemailer");
+const { buildWelcomeEmail } = require("./welcomeEmailTemplate");
 
 function getTransporter() {
   const host = process.env.SMTP_HOST;
@@ -41,4 +42,25 @@ async function sendSupportEmail({ to, subject, text, html, from }) {
   return { skipped: false, messageId: info.messageId };
 }
 
-module.exports = { sendSupportEmail };
+async function sendWelcomeEmail({ to, trailname, listUrl, unsubscribeUrl }) {
+  const transporter = getTransporter();
+  if (!transporter) {
+    console.warn("[mailer] SMTP not configured — skipping welcome email.");
+    return { skipped: true };
+  }
+
+  const from = process.env.SMTP_FROM || process.env.SMTP_USER;
+  const { html, text } = buildWelcomeEmail({ trailname, listUrl, unsubscribeUrl });
+
+  const info = await transporter.sendMail({
+    from,
+    to,
+    subject: "Your TrekList is ready — add your first item",
+    text,
+    html,
+  });
+
+  return { skipped: false, messageId: info.messageId };
+}
+
+module.exports = { sendSupportEmail, sendWelcomeEmail };

--- a/server/src/utils/welcomeEmailTemplate.js
+++ b/server/src/utils/welcomeEmailTemplate.js
@@ -1,0 +1,163 @@
+function buildWelcomeEmail({ trailname, listUrl, unsubscribeUrl }) {
+  const name = trailname || "there";
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your TrekList gear list is ready</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background-color: #e8edf2;
+      font-family: Arial, Helvetica, sans-serif;
+      color: #1e293b;
+      -webkit-text-size-adjust: 100%;
+      text-size-adjust: 100%;
+    }
+    .email-wrapper { max-width: 620px; margin: 0 auto; background-color: #ffffff; }
+    .header {
+      background-color: #0B1220;
+      padding: 22px 40px;
+      text-align: center;
+      border-bottom: 3px solid #1d4ed8;
+    }
+    .header-logo {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 22px;
+      font-weight: 700;
+      color: #ffffff;
+      text-decoration: none;
+      letter-spacing: -0.01em;
+      display: block;
+    }
+    .header-tagline {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 10px;
+      font-weight: 400;
+      color: #60a5fa;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      margin-top: 5px;
+    }
+    .content-area {
+      padding: 40px 44px;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 15px;
+      line-height: 1.7;
+      color: #1e293b;
+    }
+    .content-area p { margin-bottom: 18px; }
+    .content-area a { color: #1d4ed8; text-decoration: underline; }
+    .cta-wrap { text-align: center; margin: 32px 0; }
+    .cta-button {
+      display: inline-block;
+      background-color: #1d4ed8;
+      color: #ffffff !important;
+      text-decoration: none !important;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 15px;
+      font-weight: 700;
+      padding: 14px 32px;
+      border-radius: 6px;
+      letter-spacing: 0.01em;
+    }
+    .footer {
+      background-color: #0B1220;
+      padding: 28px 40px;
+      text-align: center;
+      border-top: 3px solid #1d4ed8;
+    }
+    .footer-logo {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 15px;
+      font-weight: 700;
+      color: #ffffff;
+      margin-bottom: 12px;
+    }
+    .footer-links { margin-bottom: 16px; }
+    .footer-links a {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      color: #60a5fa !important;
+      text-decoration: none;
+      margin: 0 10px;
+    }
+    .footer-text {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11px;
+      line-height: 1.8;
+      color: #64748b;
+    }
+    .footer-text a { color: #60a5fa !important; text-decoration: none; }
+    @media (max-width: 640px) {
+      .content-area { padding: 28px 24px; }
+      .header { padding: 20px 24px; }
+      .footer { padding: 24px 24px; }
+    }
+  </style>
+</head>
+<body>
+<div class="email-wrapper">
+
+  <div class="header">
+    <a href="https://treklist.co" class="header-logo">TrekList</a>
+    <div class="header-tagline">Free gear list planner for hikers</div>
+  </div>
+
+  <div class="content-area">
+    <p>Hey ${name},</p>
+    <p>Your list is ready whenever you are.</p>
+    <img src="https://res.cloudinary.com/treklist/image/upload/w_1080,f_png/v1779787880/Screenshot-treklist-desktop-view_x256gu.png" alt="TrekList gear list" width="540" style="max-width:100%;height:auto;display:block;margin:0 auto 24px;border-radius:6px;border:1px solid #e2e8f0;">
+    <p>If you haven't already, try adding a piece of gear you own — search the catalog or add a custom item with your own name and weight. TrekList tracks your total pack weight automatically as you go.</p>
+    <p>Once your list is complete, you can check items off as you pack and head out the door knowing you haven't forgotten a thing.</p>
+    <div class="cta-wrap">
+      <a href="${listUrl}" class="cta-button">Open my list</a>
+    </div>
+    <p>If you have any questions, just reply to this email. I'm more than happy to help!</p>
+    <p>Happy trails,<br>Tall Joe · TrekList</p>
+  </div>
+
+  <div class="footer">
+    <div class="footer-logo">TrekList</div>
+    <p class="footer-text">TrekList is made by Tall Joe Hikes</p>
+    <div class="footer-links">
+      <a href="https://treklist.co">Build a list</a>
+      <a href="https://talljoehikes.com/gear/">Gear reviews</a>
+      <a href="https://talljoehikes.com/hikes/">Hike guides</a>
+    </div>
+    <p class="footer-text">
+      You're getting this because you signed up at treklist.co<br>
+      <a href="${unsubscribeUrl}">Unsubscribe</a><br><br>
+      © 2026 TrekList · Tall Joe Hikes · Netherlands
+    </p>
+  </div>
+
+</div>
+</body>
+</html>`;
+
+  const text = `Hey ${name},
+
+Your list is ready whenever you are.
+
+${listUrl}
+
+If you haven't already, try adding a piece of gear you own — search the catalog or add a custom item with your own name and weight. TrekList tracks your total pack weight automatically as you go.
+
+Once your list is complete, you can check items off as you pack and head out the door knowing you haven't forgotten a thing.
+
+Happy trails,
+Tall Joe · TrekList
+
+---
+You're getting this because you signed up at treklist.co
+Unsubscribe: ${unsubscribeUrl}`;
+
+  return { html, text };
+}
+
+module.exports = { buildWelcomeEmail };


### PR DESCRIPTION
- Sends a welcome email 23-25h after signup to verified users who haven't returned
- Auto-loads sample list and starts tour for new users instead of showing empty state
- One-click unsubscribe removes user from transactional emails and Kit marketing
- Unsubscribed banner on landing page confirms opt-out
- Backfill script for last-30-day users (--dry-run supported)