### PR TITLE
fix: getUserLang infinite recursion from overzealous replace_all

### DIFF
--- a/client/src/pages/CommunityView.jsx
+++ b/client/src/pages/CommunityView.jsx
@@ -21,7 +21,7 @@ import { formatDistanceToNow } from "date-fns";
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
 function getUserLang() {
-  return getUserLang();
+  return localStorage.getItem("language") || navigator.language?.split("-")[0] || "en";
 }
 
 function timeAgo(date) {


### PR DESCRIPTION
replace_all replaced the function body too, making getUserLang call itself.