### PR TITLE
feat: clickable catalog item names + Decathlon bulk import scripts

### DIFF
--- a/client/src/pages/AdminView.jsx
+++ b/client/src/pages/AdminView.jsx
@@ -280,6 +280,7 @@ function GearCatalogSection({
   const [error, setError] = useState("");
   const searchTimerRef = useRef(null);
   const [editingItem, setEditingItem] = useState(null);
+  const [viewingItem, setViewingItem] = useState(null);
   const [archivingId, setArchivingId] = useState(null);
 
   const [showArchived, setShowArchived] = useState(false);
@@ -1890,7 +1891,15 @@ function GearCatalogSection({
                             <td className="px-3 py-2 align-top">
                               {item.brand || "–"}
                             </td>
-                            <td className="px-3 py-2 align-top">{item.name}</td>
+                            <td className="px-3 py-2 align-top">
+                              <button
+                                type="button"
+                                onClick={() => setViewingItem(item)}
+                                className="text-left text-primary hover:opacity-60 transition-opacity"
+                              >
+                                {item.name}
+                              </button>
+                            </td>
                             <td className="px-3 py-2 align-top">
                               {item.category || "–"}
                             </td>
@@ -2054,7 +2063,154 @@ function GearCatalogSection({
           onSaved={handleEditSaved}
         />
       )}
+
+      {viewingItem && (
+        <ViewCatalogItemModal
+          item={viewingItem}
+          onClose={() => setViewingItem(null)}
+        />
+      )}
     </section>
+  );
+}
+
+function ViewCatalogItemModal({ item, onClose }) {
+  const imageUrl = Array.isArray(item.imageUrls) && item.imageUrls[0];
+  const weightOz = item.weightGrams
+    ? (item.weightGrams / 28.3495).toFixed(1)
+    : null;
+
+  const offers = Array.isArray(item.offers) ? item.offers : [];
+
+  const attrEntries = item.attributes
+    ? Object.entries(item.attributes).filter(([, v]) => v !== null && v !== undefined && v !== "")
+    : [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="bg-base-100 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-base-200">
+          <h2 className="text-base font-semibold text-primary">Item Details</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-ghost btn-xs text-error"
+          >
+            <FiX />
+          </button>
+        </div>
+
+        <div className="px-5 py-5 space-y-4">
+          {/* Image */}
+          {imageUrl && (
+            <div className="flex justify-center">
+              <img
+                src={imageUrl}
+                alt={item.name}
+                className="max-h-48 max-w-full object-contain rounded"
+              />
+            </div>
+          )}
+
+          {/* Core fields */}
+          <div className="space-y-2 text-sm">
+            {item.itemType && (
+              <div className="flex gap-2">
+                <span className="font-medium text-primary w-28 shrink-0">Item type:</span>
+                <span className="text-primary">{item.itemType}</span>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <span className="font-medium text-primary w-28 shrink-0">Name:</span>
+              <span className="text-primary">{item.name}</span>
+            </div>
+            {item.brand && (
+              <div className="flex gap-2">
+                <span className="font-medium text-primary w-28 shrink-0">Brand:</span>
+                <span className="text-primary">{item.brand}</span>
+              </div>
+            )}
+            {item.modelNumber && (
+              <div className="flex gap-2">
+                <span className="font-medium text-primary w-28 shrink-0">Model #:</span>
+                <span className="text-primary">{item.modelNumber}</span>
+              </div>
+            )}
+            {item.category && (
+              <div className="flex gap-2">
+                <span className="font-medium text-primary w-28 shrink-0">Category:</span>
+                <span className="text-primary">
+                  {item.category}{item.subcategory ? ` / ${item.subcategory}` : ""}
+                </span>
+              </div>
+            )}
+            {weightOz && (
+              <div className="flex gap-2">
+                <span className="font-medium text-primary w-28 shrink-0">Weight:</span>
+                <span className="text-primary">{weightOz} oz ({item.weightGrams} g)</span>
+              </div>
+            )}
+          </div>
+
+          {/* Attributes */}
+          {attrEntries.length > 0 && (
+            <div className="space-y-1">
+              <div className="text-xs font-semibold text-primary uppercase tracking-wide">Attributes</div>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                {attrEntries.map(([k, v]) => (
+                  <div key={k} className="flex gap-1">
+                    <span className="font-medium text-primary capitalize shrink-0">{k}:</span>
+                    <span className="text-primary">{String(v)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          {item.description && (
+            <div className="space-y-1">
+              <div className="text-xs font-semibold text-primary uppercase tracking-wide">Description</div>
+              <p className="text-sm text-primary whitespace-pre-line">{item.description}</p>
+            </div>
+          )}
+
+          {/* Affiliate links */}
+          {offers.length > 0 && (
+            <div className="space-y-1">
+              <div className="text-xs font-semibold text-primary uppercase tracking-wide">Affiliate Links</div>
+              <div className="space-y-1">
+                {offers.map((offer, i) => {
+                  const url = offer.deepLink || offer.url || "";
+                  return (
+                    <div key={i} className="flex items-center gap-2 text-sm">
+                      <span className="text-primary shrink-0">
+                        {[offer.merchantName, offer.network, offer.region]
+                          .filter(Boolean)
+                          .join(" / ")}
+                        {url ? ":" : ""}
+                      </span>
+                      {url && (
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-500 underline truncate hover:opacity-70"
+                          title={url}
+                        >
+                          {url.length > 50 ? url.slice(0, 50) + "…" : url}
+                        </a>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "exceljs": "^4.4.0",
         "jest": "^29.7.0",
         "mongodb-memory-server": "^10.1.4",
         "mongodb-memory-server-core": "^10.1.4",
@@ -639,6 +640,51 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1356,6 +1402,104 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "license": "ISC"
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/archiver/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
@@ -1573,6 +1717,27 @@
       "license": "Apache-2.0",
       "optional": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -1596,6 +1761,30 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1608,6 +1797,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1708,6 +1916,31 @@
         "node": ">=14.20.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -1728,6 +1961,25 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1818,6 +2070,19 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2037,6 +2302,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2147,6 +2428,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -2158,6 +2446,33 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/create-jest": {
@@ -2410,6 +2725,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2458,6 +2816,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -2575,6 +2943,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/execa": {
@@ -2711,6 +3111,20 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-fifo": {
@@ -2889,6 +3303,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -2932,6 +3353,50 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -3333,12 +3798,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -3518,6 +4011,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4355,6 +4855,52 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
@@ -4413,6 +4959,52 @@
         "node": ">=0.2.0"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4423,12 +5015,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -4449,6 +5058,41 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4461,10 +5105,32 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -4485,10 +5151,31 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5489,6 +6176,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5750,6 +6444,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5879,6 +6580,39 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -6027,6 +6761,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -6098,6 +6845,13 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -6601,6 +7355,16 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6650,6 +7414,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ts-algebra": {
@@ -6733,6 +7507,58 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6922,6 +7748,13 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -7001,6 +7834,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "exceljs": "^4.4.0",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.1.4",
     "mongodb-memory-server-core": "^10.1.4",

--- a/server/scripts/bulk-import-decathlon.js
+++ b/server/scripts/bulk-import-decathlon.js
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+/**
+ * bulk-import-decathlon.js
+ *
+ * Two-phase import for Decathlon items extracted from in-store photos.
+ *
+ * Phase 1 — ref lookup:   match AffiliateProduct.merchantProductId = store ref
+ * Phase 2 — name fallback: when phase 1 fails, search by keyword terms + brand
+ *
+ * Usage:
+ *   node scripts/bulk-import-decathlon.js --dry-run   # preview only
+ *   node scripts/bulk-import-decathlon.js             # live import
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const AffiliateProduct = require("../src/models/affiliateProduct");
+const CatalogItem      = require("../src/models/catalogItem");
+const MerchantOffer    = require("../src/models/merchantOffer");
+
+const DRY_RUN     = process.argv.includes("--dry-run");
+const MERCHANT_ID = process.env.AWIN_DECATHLON_MERCHANT_ID || "26895";
+const CREATED_BY  = new mongoose.Types.ObjectId("6986dbd0fb2ab55690c5fbe9");
+
+// Only accept matches from these Decathlon own-brands.
+// Prevents NL store ref numbers colliding with unrelated UK products.
+const ALLOWED_BRANDS = new Set(["simond", "forclaz", "quechua", "decathlon"]);
+
+// ---------------------------------------------------------------------------
+// Product list extracted from in-store photos.
+//
+// ref         — Decathlon store reference number (from signage)
+// keywords    — fallback: ALL terms must appear in awin product name (case-insensitive)
+//               leave [] to skip the name-fallback for this item
+// notKeywords — terms that must NOT appear in the name (disambiguation)
+// ---------------------------------------------------------------------------
+const PRODUCTS = [
+  // ---- SLEEPING BAGS ----
+  { ref: "8799895", keywords: [] },
+  { ref: "8799893", keywords: ["MT500", "sleeping", "10°c"],  notKeywords: ["down", "15°c"] },
+  { ref: "8799889", keywords: ["MT500", "sleeping", "5°c"],   notKeywords: ["down", "15°c", "10°c", "-5°c"] },
+  { ref: "8799901", keywords: [] },
+  { ref: "8799902", keywords: [] },
+  { ref: "8407105", keywords: ["MT500", "down", "sleeping", "10°c"] },
+  { ref: "8407113", keywords: ["MT500", "down", "sleeping", "5°c"],  notKeywords: ["15°c", "10°c", "-5°c"] },
+  { ref: "8480702", keywords: ["MT900", "down", "sleeping", "0°c"] },
+  { ref: "8489109", keywords: ["makalu", "sleeping", "-5°c"] },
+  { ref: "8489191", keywords: ["makalu", "sleeping", "-9°c"] },
+  { ref: "8480193", keywords: ["makalu", "sleeping", "-12°c"] },
+
+  // ---- COOKING STOVES ----
+  { ref: "8582112", keywords: [] },
+  { ref: "8559534", keywords: [] },
+  { ref: "8559535", keywords: [] },
+  { ref: "8975262", keywords: [] },
+
+  // ---- TARPS ----
+  { ref: "8968612", keywords: [] },
+  { ref: "8968614", keywords: [] },  // already in DB
+
+  // ---- TUNNEL TENTS ----
+  { ref: "8586318", keywords: [] },
+  { ref: "8882677", keywords: [] },
+  { ref: "8882697", keywords: [] },
+
+  // ---- TENTS MT900 ----
+  { ref: "8882673", keywords: [] },
+  { ref: "8882674", keywords: [] },  // already in DB
+  { ref: "8882675", keywords: [] },
+
+  // ---- TENTS MT500 ----
+  { ref: "8786418", keywords: [] },
+  { ref: "8858233", keywords: [] },
+  { ref: "8858234", keywords: [] },
+
+  // ---- SLEEPING MATS ----
+  { ref: "5591040", keywords: ["MT100", "foam", "mattress"],      notKeywords: ["insulating"] },
+  { ref: "6492712", keywords: ["MT500", "foam", "mattress"],      notKeywords: ["insulating"] },
+  // MT100 insulating foam — no UK equivalent found; will fall through to NOT FOUND
+  { ref: "8801325", keywords: [] },
+  { ref: "8612278", keywords: [] },
+  { ref: "8612279", keywords: [] },  // already in DB
+  { ref: "8799965", keywords: [] },
+  { ref: "8799966", keywords: [] },
+  { ref: "8853280", keywords: [] },
+  { ref: "8853281", keywords: [] },
+  { ref: "8975036", keywords: [] },
+  { ref: "8799038", keywords: ["MT900", "air", "mattress", "XL"],  notKeywords: ["insulating"] },
+  { ref: "8975202", keywords: [] },
+  { ref: "8975212", keywords: [] },
+  { ref: "8817232", keywords: [] },
+
+  // ---- WOMEN'S HIKING BOOTS ----
+  { ref: "8553549", keywords: [] },
+  { ref: "8930406", keywords: [] },
+  { ref: "8871776", keywords: [] },
+  { ref: "8870065", keywords: ["NH100", "mid", "waterproof", "women", "boot"] },
+  { ref: "8934985", keywords: ["NH500", "low", "women",  "boot"],    notKeywords: ["tank", "jacket", "trouser", "nh500 mid"] },
+  { ref: "8969434", keywords: ["NH500", "low", "waterproof", "women", "boot"] },
+  { ref: "8871375", keywords: [] },
+  { ref: "8884466", keywords: ["NH500", "mid", "leather", "women",   "boot"] },
+
+  // ---- MEN'S HIKING BOOTS ----
+  // notKeywords: ["nh500"] prevents "NH50" regex matching "NH500" items
+  { ref: "8844096", keywords: ["nh50", "men",  "boot"],              notKeywords: ["nh500", "women"] },
+  { ref: "8780701", keywords: ["NH100", "mid",  "men",  "boot"],     notKeywords: ["women"] },
+  // 8877180 was brand-mismatch by ref; try by name
+  { ref: "8877180", keywords: ["NH100", "low",  "men",  "boot"],     notKeywords: ["women"] },
+  { ref: "8894871", keywords: ["NH100", "mid",  "waterproof", "men", "boot"], notKeywords: ["women"] },
+  { ref: "8931885", keywords: ["NH500", "low",  "men",  "boot"],     notKeywords: ["women", "tank", "jacket", "trouser", "waterproof"] },
+  { ref: "8940976", keywords: ["arpenaz", "revival"] },
+  { ref: "8930684", keywords: ["NH500", "low",  "waterproof", "men", "boot"], notKeywords: ["women"] },
+  { ref: "8988718", keywords: ["NH500", "mid",  "leather", "waterproof", "men", "boot"], notKeywords: ["women"] },
+  { ref: "8883913", keywords: ["NH500", "mid",  "leather", "men",  "boot"],   notKeywords: ["women", "waterproof"] },
+
+  // ---- TREKKING BOOTS ----
+  { ref: "8883388", keywords: ["MT100", "trekking", "boot", "men"], notKeywords: ["women", "spare", "lower"] },
+  { ref: "8550247", keywords: [] },
+  { ref: "8788855", keywords: ["MT500", "leather", "trekking", "boot"], notKeywords: ["women", "spare"] },
+
+  // ---- MOUNTAIN BOOTS ----
+  { ref: "8755055", keywords: ["MH100", "boot",  "men"],   notKeywords: ["women", "jacket"] },
+  { ref: "8710204", keywords: ["MH100", "waterproof", "boot", "men"], notKeywords: ["women", "jacket"] },
+  { ref: "8799992", keywords: ["MH100", "mid", "waterproof", "boot", "men"], notKeywords: ["women", "jacket"] },
+  { ref: "8723811", keywords: ["MH500", "waterproof", "boot", "men"], notKeywords: ["women", "jacket"] },
+  { ref: "8723616", keywords: ["MH500", "mid", "waterproof", "boot"], notKeywords: ["women", "jacket"] },
+
+  // ---- HIKING BACKPACKS ----
+  { ref: "8740470", keywords: ["MH100", "20",  "backpack"] },
+  { ref: "8790270", keywords: ["MH100", "35",  "backpack"] },
+  { ref: "8910354", keywords: ["MH500", "25",  "backpack"],  notKeywords: ["light"] },
+  { ref: "8920390", keywords: ["MH500", "38",  "backpack"],  notKeywords: ["light"] },
+  { ref: "8870393", keywords: ["MH500", "15",  "light",  "backpack"] },
+  { ref: "8813394", keywords: ["MH500", "22",  "light",  "backpack"] },
+  { ref: "8884020", keywords: ["FH500", "17"] },
+  { ref: "8881199", keywords: ["MH900", "25",  "backpack"] },
+  { ref: "8946339", keywords: ["MH900", "38",  "backpack"] },
+
+  // ---- TREKKING BACKPACKS ----
+  { ref: "8559800", keywords: ["MT100", "trekking", "50",  "men"],        notKeywords: ["women", "spare"] },
+  { ref: "8731082", keywords: ["MT100", "trekking", "women"],             notKeywords: ["spare"] },
+  { ref: "8978310", keywords: [] },
+  { ref: "8898272", keywords: ["MT500", "trekking", "women",  "backpack"] },
+  { ref: "8842899", keywords: ["MT900", "light",    "backpack", "men"],   notKeywords: ["women", "spare"] },
+  { ref: "8842604", keywords: ["MT900", "light",    "backpack", "women"] },
+  { ref: "8781983", keywords: ["MT800", "trekking", "men"],               notKeywords: ["women", "spare"] },
+  { ref: "8732034", keywords: ["MT800", "trekking", "women"] },
+  { ref: "8879319", keywords: ["MT800", "ultra",    "50",  "backpack"] },
+
+  // ---- HIKING POLES ----
+  { ref: "8807204", keywords: [] },
+  { ref: "8905507", keywords: ["MT100", "comfort", "pole"],    notKeywords: ["spare", "segment", "part", "lower"] },
+  { ref: "8807205", keywords: [] },
+  { ref: "8870985", keywords: ["MT500", "ergonomic", "pole"],  notKeywords: ["spare", "segment", "part"] },
+  { ref: "8840581", keywords: ["MT500", "pole"],               notKeywords: ["spare", "segment", "ring", "part", "tent", "antishock", "cork", "ergonomic"] },
+  { ref: "8910014", keywords: ["MT500", "all season", "pole"], notKeywords: ["spare", "segment", "part"] },
+  { ref: "8810080", keywords: ["MT500", "antishock", "pole"],  notKeywords: ["spare", "segment", "part"] },
+  { ref: "8869228", keywords: ["MT500", "cork", "pole"],       notKeywords: ["spare", "segment", "part"] },
+  { ref: "8810058", keywords: ["MT900", "trekking", "pole"],   notKeywords: ["spare", "segment", "section", "tent", "part"] },
+  { ref: "8793383", keywords: ["sprint", "pole"],              notKeywords: ["spare", "segment", "repair", "lower", "part"] },
+
+  // ---- TRAVEL BACKPACKS ----
+  { ref: "8990286", keywords: ["travel", "500", "30",  "backpack"] },
+  { ref: "8787845", keywords: [] },
+  { ref: "8880000", keywords: ["travel", "900", "50",  "men's"],   notKeywords: ["women", "removable", "accessory"] },
+  { ref: "8816394", keywords: ["travel", "900", "50",  "women"],   notKeywords: ["removable", "accessory"] },
+  { ref: "8880014", keywords: ["travel", "900", "70",  "men"],     notKeywords: ["women", "removable", "accessory", "top"] },
+  { ref: "8880010", keywords: ["travel", "900", "60",  "women"],   notKeywords: ["removable", "accessory"] },
+
+  // ---- CAMP LIGHTS ----
+  { ref: "8615283", keywords: [] },
+  { ref: "8492468", keywords: [] },
+  { ref: "8755548", keywords: [] },
+  { ref: "8670110", keywords: [] },
+  { ref: "8881742", keywords: [] },
+  { ref: "8852787", keywords: [] },
+  { ref: "8492469", keywords: [] },
+  { ref: "8492095", keywords: ["BL400", "lamp"],    notKeywords: ["spare", "battery replacement"] },
+  { ref: "8649378", keywords: [] },
+  { ref: "8948415", keywords: [] },
+  { ref: "8665145", keywords: [] },
+  { ref: "8665147", keywords: [] },
+  { ref: "8665150", keywords: [] },
+
+  // ---- HEADLAMPS ----
+  { ref: "8786370", keywords: ["HL50",  "headlamp"],           notKeywords: ["HL500", "spare", "battery"] },
+  { ref: "8384891", keywords: ["onnight", "headlamp"],         notKeywords: ["spare", "battery"] },
+  { ref: "8979230", keywords: ["HL900"],                       notKeywords: ["spare", "battery", "replacement"] },
+  { ref: "8978237", keywords: [] },
+  { ref: "8858783", keywords: ["sprint", "400", "headlamp"],   notKeywords: ["spare", "battery", "900"] },
+  { ref: "8813317", keywords: ["sprint", "900", "headlamp"],   notKeywords: ["spare", "battery", "400"] },
+  // Removed: 8787287 (lanyard collision), 8505882 (tennis cap), 8919550 (bike part),
+  //          8501304/8501305 (Solognac hunting brand), 8877180 phase-1 brand-mismatch handled above
+];
+
+// ---------------------------------------------------------------------------
+// Build a regex that requires ALL keywords to appear AND none of notKeywords.
+// Escape everything except ° (not a regex metachar, safe to leave as-is).
+// ---------------------------------------------------------------------------
+function esc(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
+function buildKeywordRegex(keywords, notKeywords = []) {
+  const pos = keywords.map((k)    => `(?=.*${esc(k)})`).join("");
+  const neg = notKeywords.map((k) => `(?!.*${esc(k)})`).join("");
+  // ^ anchors the lookaheads to the start of the string so negative terms
+  // cannot be dodged by matching from a later character position.
+  return new RegExp("^" + neg + pos, "i");
+}
+
+// ---------------------------------------------------------------------------
+// Deduplicate a list of AffiliateProducts by merchantProductId.
+// Prefer rows that have an image; return one per base product code.
+// ---------------------------------------------------------------------------
+function dedupByMerchantProductId(products) {
+  const seen = new Map();
+  for (const p of products) {
+    const key = p.merchantProductId || p.externalProductId;
+    if (!seen.has(key) || (!seen.get(key).imageUrl && p.imageUrl)) {
+      seen.set(key, p);
+    }
+  }
+  return Array.from(seen.values());
+}
+
+// ---------------------------------------------------------------------------
+// MAIN
+// ---------------------------------------------------------------------------
+async function main() {
+  const uri = process.env.MONGO_URI;
+  if (!uri) { console.error("Missing MONGO_URI"); process.exit(1); }
+
+  await mongoose.connect(uri, { dbName: "TrekList" });
+  console.log(`Connected to DB: ${mongoose.connection.name}`);
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN (no writes)" : "LIVE"}`);
+  console.log(`Processing ${PRODUCTS.length} items...\n`);
+
+  const results = {
+    importedByRef:   [],
+    importedByName:  [],
+    alreadyExists:   [],
+    notFound:        [],
+    errors:          [],
+  };
+
+  for (const { ref, keywords, notKeywords = [] } of PRODUCTS) {
+    try {
+      // 0. Check already imported
+      const existing = await CatalogItem.findOne({
+        $or: [
+          { "externalIds.sku": ref },
+          { canonicalSku: ref },
+          { modelNumber: ref },
+        ],
+      }).lean();
+
+      if (existing) {
+        results.alreadyExists.push({ ref, name: existing.name });
+        console.log(`  [EXISTS]         ${ref}  →  "${existing.name}"`);
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // PHASE 1: exact ref lookup
+      // ------------------------------------------------------------------
+      let product = null;
+      let matchedBy = null;
+
+      if (ref) {
+        const byRef = await AffiliateProduct.find({
+          network:           "awin",
+          merchantId:        MERCHANT_ID,
+          merchantProductId: ref,
+          brand:             { $regex: /simond|forclaz|quechua|decathlon/i },
+        }).sort({ updatedAt: -1 }).limit(50).lean();
+
+        if (byRef.length) {
+          const deduped = dedupByMerchantProductId(byRef);
+          product   = deduped[0];
+          matchedBy = "ref";
+        }
+      }
+
+      // ------------------------------------------------------------------
+      // PHASE 2: name/keyword fallback
+      // ------------------------------------------------------------------
+      if (!product && keywords.length > 0) {
+        const regex = buildKeywordRegex(keywords, notKeywords);
+        const byName = await AffiliateProduct.find({
+          network:   "awin",
+          merchantId: MERCHANT_ID,
+          brand:     { $regex: /simond|forclaz|quechua|decathlon/i },
+          name:      { $regex: regex },
+        }).sort({ updatedAt: -1 }).limit(50).lean();
+
+        if (byName.length) {
+          const deduped = dedupByMerchantProductId(byName);
+          product   = deduped[0];
+          matchedBy = "name";
+        }
+      }
+
+      if (!product) {
+        results.notFound.push({ ref });
+        console.log(`  [NOT FOUND]      ${ref}`);
+        continue;
+      }
+
+      // Guard against two NL refs mapping to the same awin product (colour/size
+      // variants collapsed to one representative above). If we already imported
+      // this awin externalProductId under a previous ref, skip rather than error.
+      const existingByAwin = await CatalogItem.findOne({
+        "externalIds.sku": product.externalProductId,
+      }).lean();
+      if (existingByAwin) {
+        results.alreadyExists.push({ ref, name: existingByAwin.name });
+        console.log(`  [EXISTS-AWIN]    ${ref}  →  "${existingByAwin.name}" (same awin product)`);
+        continue;
+      }
+
+      // ------------------------------------------------------------------
+      // Log / import
+      // ------------------------------------------------------------------
+      const weightGrams = product.deliveryWeightKg
+        ? Math.round(product.deliveryWeightKg * 1000)
+        : undefined;
+
+      const imageUrls = product.imageUrls?.length
+        ? product.imageUrls
+        : product.imageUrl ? [product.imageUrl] : [];
+
+      const tag = matchedBy === "name" ? "[DRY-NAME]  " : "[DRY-REF]   ";
+      const liveTag = matchedBy === "name" ? "[IMPORT-NAME]" : "[IMPORT-REF] ";
+
+      if (DRY_RUN) {
+        console.log(`  ${tag}    ${ref}  →  "${product.name}"  (${product.brand})  ${weightGrams ? weightGrams + "g" : "no weight"}  images:${imageUrls.length}`);
+        (matchedBy === "name" ? results.importedByName : results.importedByRef)
+          .push({ ref, name: product.name, brand: product.brand, weightGrams, matchedBy });
+        continue;
+      }
+
+      // Create CatalogItem
+      const catalogItem = await new CatalogItem({
+        name:        product.name,
+        brand:       product.brand || "Decathlon",
+        description: product.description || undefined,
+        imageUrls,
+        weightGrams,
+        modelNumber: product.modelNumber || undefined,
+        itemGroupId: product.itemGroupId || undefined,
+        externalIds: {
+          ean: product.ean || undefined,
+          sku: product.externalProductId,
+        },
+        canonicalSku: ref || undefined,
+        createdBy:    CREATED_BY,
+        isActive:     true,
+      }).save();
+
+      // Create MerchantOffer
+      await MerchantOffer.findOneAndUpdate(
+        {
+          network:           "awin",
+          region:            "uk",
+          merchantId:        MERCHANT_ID,
+          externalProductId: product.externalProductId,
+        },
+        {
+          $set: {
+            productId:    catalogItem._id,
+            merchantName: product.merchantName || "Decathlon UK",
+            deepLink:     product.awDeepLink,
+            updatedAt:    new Date(),
+          },
+          $setOnInsert: {
+            network:           "awin",
+            region:            "uk",
+            merchantId:        MERCHANT_ID,
+            externalProductId: product.externalProductId,
+            priority:          0,
+          },
+        },
+        { upsert: true, new: true }
+      );
+
+      console.log(`  ${liveTag}  ${ref}  →  "${product.name}"  (${product.brand})`);
+      (matchedBy === "name" ? results.importedByName : results.importedByRef)
+        .push({ ref, name: product.name, brand: product.brand, weightGrams, matchedBy });
+
+    } catch (err) {
+      console.error(`  [ERROR]          ${ref}  →  ${err.message}`);
+      results.errors.push({ ref, error: err.message });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Summary
+  // ---------------------------------------------------------------------------
+  const totalImported = results.importedByRef.length + results.importedByName.length;
+  console.log("\n" + "=".repeat(64));
+  console.log(`SUMMARY (${DRY_RUN ? "DRY RUN" : "LIVE"})`);
+  console.log("=".repeat(64));
+  console.log(`  Matched by ref  (or would): ${results.importedByRef.length}`);
+  console.log(`  Matched by name (or would): ${results.importedByName.length}`);
+  console.log(`  Total to import:            ${totalImported}`);
+  console.log(`  Already in DB (skipped):    ${results.alreadyExists.length}`);
+  console.log(`  Not found in either phase:  ${results.notFound.length}`);
+  console.log(`  Errors:                     ${results.errors.length}`);
+
+  if (results.notFound.length) {
+    console.log("\nNot found (not in UK awin feed):");
+    results.notFound.forEach(({ ref }) => console.log(`    ${ref}`));
+  }
+
+  if (results.errors.length) {
+    console.log("\nErrors:");
+    results.errors.forEach(({ ref, error }) => console.log(`    ${ref}: ${error}`));
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/scripts/export-decathlon-items.js
+++ b/server/scripts/export-decathlon-items.js
@@ -1,0 +1,471 @@
+#!/usr/bin/env node
+/**
+ * export-decathlon-items.js
+ *
+ * 1. Exports all Decathlon-brand CatalogItems (Forclaz, Quechua, Simond, Decathlon)
+ *    plus any CatalogItem with an awin MerchantOffer linked — to an Excel file.
+ * 2. Compares against products extracted from in-store photos.
+ * 3. Outputs a second sheet listing items from photos NOT yet in the DB.
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const ExcelJS = require("exceljs");
+const path = require("path");
+
+const CatalogItem = require("../src/models/catalogItem");
+const MerchantOffer = require("../src/models/merchantOffer");
+
+// ---------------------------------------------------------------------------
+// Products extracted from in-store photos (name, decathlonRef, weight, category, notes)
+// decathlonRef = the numeric reference printed on store signage
+// ---------------------------------------------------------------------------
+const IMAGE_PRODUCTS = [
+  // ---- SLEEPING BAGS (Simond) ----
+  { name: "Sleeping Bag MT500 15°C", decathlonRef: "8799895", weightG: 660, category: "Sleep System", brand: "Simond", notes: "Slaapzak" },
+  { name: "Sleeping Bag MT500 10°C", decathlonRef: "8799893", weightG: 900, category: "Sleep System", brand: "Simond", notes: "" },
+  { name: "Sleeping Bag MT500 5°C", decathlonRef: "8799889", weightG: 1050, category: "Sleep System", brand: "Simond", notes: "" },
+  { name: "Sleeping Bag MT500 0°C", decathlonRef: "8799901", weightG: 1450, category: "Sleep System", brand: "Simond", notes: "" },
+  { name: "Sleeping Bag MT500 -5°C", decathlonRef: "8799902", weightG: 1650, category: "Sleep System", brand: "Simond", notes: "" },
+  { name: "Sleeping Bag MT500 10°C Dons", decathlonRef: "8407105", weightG: 630, category: "Sleep System", brand: "Simond", notes: "100% gerecycled eendendons 700 Cuin" },
+  { name: "Sleeping Bag MT500 5°C Dons", decathlonRef: "8407113", weightG: 830, category: "Sleep System", brand: "Simond", notes: "100% gerecycled eendendons 700 Cuin" },
+  { name: "Sleeping Bag MT900 0°C Dons", decathlonRef: "8480702", weightG: 930, category: "Sleep System", brand: "Simond", notes: "Eendendons" },
+  { name: "Sleeping Bag QUILT SPRINT 0°C Dons", decathlonRef: "", weightG: 695, category: "Sleep System", brand: "Simond", notes: "Ganzensdons RDS 900 Cuin" },
+  { name: "Sleeping Bag MAKALU I -5°C", decathlonRef: "8489109", weightG: 1160, category: "Sleep System", brand: "Simond", notes: "" },
+  { name: "Sleeping Bag MAKALU II -9°C", decathlonRef: "8489191", weightG: 1471, category: "Sleep System", brand: "Simond", notes: "Eendendons RDS 800 Cuin" },
+  { name: "Sleeping Bag MAKALU III -12°C", decathlonRef: "8480193", weightG: 1840, category: "Sleep System", brand: "Simond", notes: "" },
+
+  // ---- COOKING STOVES ----
+  { name: "Camp Stove Bleuet Compact Connect", decathlonRef: "8989039", weightG: 193, category: "Kitchen", brand: "Campingaz", notes: "1250W, Ventielpatroon" },
+  { name: "Camp Stove MT100", decathlonRef: "8582112", weightG: 184, category: "Kitchen", brand: "Simond", notes: "2200W" },
+  { name: "Camp Stove MT500 Light", decathlonRef: "8559534", weightG: 85, category: "Kitchen", brand: "Simond", notes: "2750W" },
+  { name: "Camp Stove MT500 Remonte", decathlonRef: "8559535", weightG: 170, category: "Kitchen", brand: "Simond", notes: "2500W" },
+  { name: "Camp Stove MT900", decathlonRef: "8975262", weightG: 50, category: "Kitchen", brand: "Simond", notes: "2300W" },
+  { name: "Camp Stove Jetboil Zip 2.0", decathlonRef: "9030015", weightG: 324, category: "Kitchen", brand: "Jetboil", notes: "900W" },
+
+  // ---- TARPS (Simond) ----
+  { name: "Tarp MT900 1P", decathlonRef: "8968612", weightG: 920, category: "Shelter", brand: "Simond", notes: "Tarp 1 persoon" },
+  { name: "Tarp MT900 2P", decathlonRef: "8968614", weightG: 1300, category: "Shelter", brand: "Simond", notes: "Tarp 2 personen" },
+
+  // ---- TUNNEL TENTS (Simond) ----
+  { name: "Tunneltent UL MT900 2P", decathlonRef: "8586318", weightG: 1650, category: "Shelter", brand: "Simond", notes: "Ultralicht tunneltent 2P" },
+  { name: "Tunneltent MT900 2P", decathlonRef: "8882677", weightG: 2080, category: "Shelter", brand: "Simond", notes: "Tunneltent 2P" },
+  { name: "Tunneltent MT900 3P", decathlonRef: "8882697", weightG: 3080, category: "Shelter", brand: "Simond", notes: "Tunneltent 3P" },
+
+  // ---- TENTS MT900 (Simond) ----
+  { name: "Tent MT900 1P", decathlonRef: "8882673", weightG: 1300, category: "Shelter", brand: "Simond", notes: "Tent 1P" },
+  { name: "Tent MT900 2P", decathlonRef: "8882674", weightG: 1950, category: "Shelter", brand: "Simond", notes: "Tent 2P (also ref 8975216)" },
+  { name: "Tent MT900 3P", decathlonRef: "8882675", weightG: 2700, category: "Shelter", brand: "Simond", notes: "Tent 3P" },
+
+  // ---- TENTS MT500 (Simond) ----
+  { name: "Tent MT500 Mesh 2P", decathlonRef: "8786418", weightG: 2600, category: "Shelter", brand: "Simond", notes: "Mesh tent 2P" },
+  { name: "Tent MT500 2P", decathlonRef: "8858233", weightG: 2850, category: "Shelter", brand: "Simond", notes: "Tent 2P" },
+  { name: "Tent MT500 3P", decathlonRef: "8858234", weightG: 3650, category: "Shelter", brand: "Simond", notes: "Tent 3P" },
+
+  // ---- SLEEPING MATS ----
+  { name: "Sleeping Mat MT100 Schuim", decathlonRef: "5591040", weightG: 210, category: "Sleep System", brand: "Simond", notes: "180x50x0.7cm, R=1, Foam" },
+  { name: "Sleeping Mat MT500 Schuim", decathlonRef: "6492712", weightG: 370, category: "Sleep System", brand: "Simond", notes: "180x55x2cm, R=2.1, Foam" },
+  { name: "Sleeping Mat MT100 Schuim Isolerend", decathlonRef: "8801325", weightG: 480, category: "Sleep System", brand: "Simond", notes: "195x55x2cm, R=2.2, Foam" },
+  { name: "Sleeping Mat MT100 Zelfopblazend L", decathlonRef: "8612278", weightG: 920, category: "Sleep System", brand: "Simond", notes: "180x52x2.5cm, R=2.7, Self-inflating" },
+  { name: "Sleeping Mat MT100 Zelfopblazend XL", decathlonRef: "8612279", weightG: 1020, category: "Sleep System", brand: "Simond", notes: "193x60x2.5cm, R=2.7, Self-inflating" },
+  { name: "Sleeping Mat MT500 Air L", decathlonRef: "8799965", weightG: 510, category: "Sleep System", brand: "Simond", notes: "180x52x5cm, R=1.5, Inflatable" },
+  { name: "Sleeping Mat MT500 Air XL", decathlonRef: "8799966", weightG: 600, category: "Sleep System", brand: "Simond", notes: "195x60x5cm, R=1.5, Inflatable" },
+  { name: "Sleeping Mat MT500 Isolerend L", decathlonRef: "8853280", weightG: 670, category: "Sleep System", brand: "Simond", notes: "180x52x5cm, R=3.3, Inflatable" },
+  { name: "Sleeping Mat MT500 Isolerend XL", decathlonRef: "8853281", weightG: 800, category: "Sleep System", brand: "Simond", notes: "195x60x5cm, R=3.3, Inflatable" },
+  { name: "Sleeping Mat MT900 Air L", decathlonRef: "8975036", weightG: 520, category: "Sleep System", brand: "Simond", notes: "183x54x8.5cm, R=1.5, Inflatable" },
+  { name: "Sleeping Mat MT900 Air XL", decathlonRef: "8799038", weightG: 620, category: "Sleep System", brand: "Simond", notes: "195x63x8.5cm, R=1.5, Inflatable" },
+  { name: "Sleeping Mat MT900 Air Isolerend L", decathlonRef: "8975202", weightG: 615, category: "Sleep System", brand: "Simond", notes: "183x54x9cm, R=5.4, Inflatable" },
+  { name: "Sleeping Mat MT900 Air Isolerend XL", decathlonRef: "8975212", weightG: 730, category: "Sleep System", brand: "Simond", notes: "195x63x9cm, R=5.4, Inflatable" },
+  { name: "Sleeping Mat Sea to Summit Ultralight Insulated L", decathlonRef: "8951198", weightG: 480, category: "Sleep System", brand: "Sea to Summit", notes: "183x55x5cm, R=3.1, Inflatable" },
+  { name: "Sleeping Mat Sea to Summit Ultralight Insulated XL", decathlonRef: "8951198", weightG: 595, category: "Sleep System", brand: "Sea to Summit", notes: "198x64x5cm, R=3.1, Inflatable" },
+  { name: "Set Reparatiepatch slaapmat", decathlonRef: "8817232", weightG: null, category: "Accessories", brand: "Simond", notes: "Repair patch set" },
+
+  // ---- WOMEN'S HIKING BOOTS (NH series - Dames) ----
+  { name: "NH50 LOW Women", decathlonRef: "8553549", weightG: 270, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames" },
+  { name: "NH100 MID Women", decathlonRef: "8930406", weightG: 312, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames" },
+  { name: "NH100 LOW WTP Women", decathlonRef: "8871776", weightG: 300, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames waterproof" },
+  { name: "NH100 MID WTP Women", decathlonRef: "8870065", weightG: 310, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames mid waterproof" },
+  { name: "NH500 LOW Women", decathlonRef: "8934985", weightG: 240, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames" },
+  { name: "NH500 LOW WP Women", decathlonRef: "8969434", weightG: 300, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames waterproof" },
+  { name: "NH500 LOW LEER WP Women", decathlonRef: "8871375", weightG: 300, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames leer waterproof" },
+  { name: "NH500 MID LEER WP Women", decathlonRef: "8884466", weightG: 325, category: "Footwear", brand: "Quechua", notes: "Wandelschoen dames mid leer waterproof" },
+
+  // ---- MEN'S HIKING BOOTS (NH series - Heren) ----
+  { name: "NH50 LOW Men", decathlonRef: "8844096", weightG: 361, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren" },
+  { name: "NH100 MID Men", decathlonRef: "8780701", weightG: 371, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren" },
+  { name: "NH100 LOW WTP Men", decathlonRef: "8877180", weightG: 325, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren waterproof" },
+  { name: "NH100 MID WTP Men", decathlonRef: "8894871", weightG: 365, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren mid waterproof" },
+  { name: "NH500 LOW Men", decathlonRef: "8931885", weightG: 325, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren" },
+  { name: "ARPENAZ REVIVAL Men", decathlonRef: "8940976", weightG: 265, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren" },
+  { name: "NH500 LOW WP Men", decathlonRef: "8930684", weightG: 375, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren waterproof" },
+  { name: "NH500 MID LEER WP Men", decathlonRef: "8988718", weightG: 403, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren mid leer waterproof" },
+  { name: "NH500 MID LEER Men", decathlonRef: "8883913", weightG: 425, category: "Footwear", brand: "Quechua", notes: "Wandelschoen heren mid leer" },
+
+  // ---- MEN'S TREKKING BOOTS ----
+  { name: "Trekking Boot MT100", decathlonRef: "8883388", weightG: 560, category: "Footwear", brand: "Forclaz", notes: "Trekkingschoen heren" },
+  { name: "Trekking Boot MT100 LEER BREED", decathlonRef: "8550247", weightG: 627, category: "Footwear", brand: "Forclaz", notes: "Trekkingschoen heren breed" },
+  { name: "Trekking Boot TECNICA STARCROSS", decathlonRef: "9054921", weightG: 500, category: "Footwear", brand: "Tecnica", notes: "Trekkingschoen heren" },
+  { name: "Trekking Boot MT500 LEER", decathlonRef: "8788855", weightG: 552, category: "Footwear", brand: "Forclaz", notes: "Trekkingschoen heren leer" },
+  { name: "Trekking Boot SALEWA ALP TRAINER MID", decathlonRef: "9000448", weightG: 532, category: "Footwear", brand: "Salewa", notes: "Trekkingschoen heren" },
+  { name: "Trekking Boot LOWA RENETREK GTX", decathlonRef: "9007426", weightG: 590, category: "Footwear", brand: "Lowa", notes: "Trekkingschoen heren" },
+  { name: "Trekking Boot SALOMON QUEST 4", decathlonRef: "9020991", weightG: 585, category: "Footwear", brand: "Salomon", notes: "Trekkingschoen heren" },
+  { name: "Trekking Boot TECNICA FUSE", decathlonRef: "", weightG: 560, category: "Footwear", brand: "Tecnica", notes: "Trekkingschoen heren" },
+
+  // ---- MEN'S MOUNTAIN HIKING BOOTS ----
+  { name: "Mountain Boot MH100", decathlonRef: "8755055", weightG: null, category: "Footwear", brand: "Quechua", notes: "Bergwandelschoen heren" },
+  { name: "Mountain Boot MH100 WP", decathlonRef: "8710204", weightG: null, category: "Footwear", brand: "Quechua", notes: "Bergwandelschoen heren WP" },
+  { name: "Mountain Boot MH100 MID WP", decathlonRef: "8799992", weightG: null, category: "Footwear", brand: "Quechua", notes: "Bergwandelschoen heren mid WP" },
+  { name: "Mountain Boot MH500 WP", decathlonRef: "8723811", weightG: null, category: "Footwear", brand: "Quechua", notes: "Bergwandelschoen heren WP" },
+  { name: "Mountain Boot MH500 MID WP", decathlonRef: "8723616", weightG: null, category: "Footwear", brand: "Quechua", notes: "Bergwandelschoen heren mid WP" },
+  { name: "Mountain Boot MERRELL CROSSLANDER", decathlonRef: "8923385", weightG: null, category: "Footwear", brand: "Merrell", notes: "Bergwandelschoen heren" },
+  { name: "Mountain Boot COLUMBIA DIAMOND", decathlonRef: "8981294", weightG: null, category: "Footwear", brand: "Columbia", notes: "Bergwandelschoen heren" },
+  { name: "Mountain Boot COLUMBIA DIAMOND MID", decathlonRef: "9012380", weightG: null, category: "Footwear", brand: "Columbia", notes: "Bergwandelschoen heren mid" },
+  { name: "Mountain Boot MERRELL MOAB MID", decathlonRef: "9012460", weightG: null, category: "Footwear", brand: "Merrell", notes: "Bergwandelschoen heren mid" },
+  { name: "Mountain Boot LOWA SIRKOS GTX LO DC", decathlonRef: "9012730", weightG: null, category: "Footwear", brand: "Lowa", notes: "Bergwandelschoen heren" },
+  { name: "Mountain Boot SALEWA ALP TRAINER", decathlonRef: "9012228", weightG: null, category: "Footwear", brand: "Salewa", notes: "Bergwandelschoen heren" },
+
+  // ---- HIKING BACKPACKS (Quechua) ----
+  { name: "Hiking Pack MH100 20L", decathlonRef: "8740470", weightG: 740, category: "Pack", brand: "Quechua", notes: "Wandelrugzak 20L, 40x25x17.6cm" },
+  { name: "Hiking Pack MH100 35L", decathlonRef: "8790270", weightG: 840, category: "Pack", brand: "Quechua", notes: "Wandelrugzak 35L, 40x29x22cm" },
+  { name: "Hiking Pack MH500 25L", decathlonRef: "8910354", weightG: 975, category: "Pack", brand: "Quechua", notes: "Wandelrugzak 25L" },
+  { name: "Hiking Pack MH500 38L", decathlonRef: "8920390", weightG: 1150, category: "Pack", brand: "Quechua", notes: "Wandelrugzak 38L" },
+  { name: "Hiking Pack MH500 LIGHT 15L", decathlonRef: "8870393", weightG: 550, category: "Pack", brand: "Quechua", notes: "Wandelrugzak licht 15L" },
+  { name: "Hiking Pack MH500 LIGHT 22L", decathlonRef: "8813394", weightG: 780, category: "Pack", brand: "Quechua", notes: "Wandelrugzak licht 22L" },
+  { name: "Hiking Pack FH500 17L", decathlonRef: "8884020", weightG: 400, category: "Pack", brand: "Quechua", notes: "Snelwandelen 17L" },
+  { name: "Hiking Pack MH900 25L", decathlonRef: "8881199", weightG: 1080, category: "Pack", brand: "Quechua", notes: "Intensief wandelen 25L" },
+  { name: "Hiking Pack MH900 38L", decathlonRef: "8946339", weightG: 1160, category: "Pack", brand: "Quechua", notes: "Intensief wandelen 38L" },
+
+  // ---- TREKKING BACKPACKS (Simond) ----
+  { name: "Trekking Pack MT100 50L", decathlonRef: "", weightG: 1400, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 50L" },
+  { name: "Trekking Pack MT100 Easyfit 50+10L (Men)", decathlonRef: "8559800", weightG: 1600, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 50+10L heren" },
+  { name: "Trekking Pack MT100 Easyfit 60+10L (Women)", decathlonRef: "8731082", weightG: 1700, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 60+10L dames" },
+  { name: "Trekking Pack MT500 Air 45+10L (Men)", decathlonRef: "8978310", weightG: 1600, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 45+10L heren" },
+  { name: "Trekking Pack MT500 Air (Women)", decathlonRef: "8898272", weightG: 1730, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak dames" },
+  { name: "Trekking Pack MT900 Light 50+10L (Men)", decathlonRef: "8842899", weightG: 1300, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak licht 50+10L heren" },
+  { name: "Trekking Pack MT900 Light 45+10L (Women)", decathlonRef: "8842604", weightG: 1300, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak licht 45+10L dames" },
+  { name: "Trekking Pack MT800 Symbium (Men)", decathlonRef: "8781983", weightG: null, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 50-90+10L heren" },
+  { name: "Trekking Pack MT800 Symbium (Women)", decathlonRef: "8732034", weightG: null, category: "Pack", brand: "Simond", notes: "Trekkingsrugzak 50-80+10L dames" },
+  { name: "Trekking Pack MT800 UL 50L", decathlonRef: "8879319", weightG: 680, category: "Pack", brand: "Simond", notes: "Ultralicht trekkingsrugzak 50L" },
+  { name: "Trekking Pack Deuter Trekking Plus 45+10L", decathlonRef: "9008928", weightG: 1890, category: "Pack", brand: "Deuter", notes: "Trekkingsrugzak dames 45+10L" },
+
+  // ---- HIKING POLES (Quechua) ----
+  { name: "Hiking Pole MT100", decathlonRef: "8807204", weightG: 200, category: "Poles", brand: "Quechua", notes: "Per stok, 105-120cm, compact 56cm" },
+  { name: "Hiking Pole MT100 Comfort", decathlonRef: "8905507", weightG: 230, category: "Poles", brand: "Quechua", notes: "Per stok, 110-130cm, compact 57cm" },
+  { name: "Hiking Pole MT100 Ergonomisch", decathlonRef: "8807205", weightG: 240, category: "Poles", brand: "Quechua", notes: "Per stok, 90-110cm, compact 58cm" },
+  { name: "Hiking Pole MT500 Ergonomisch", decathlonRef: "8870985", weightG: 240, category: "Poles", brand: "Quechua", notes: "Per stok, 90-110cm, compact 58cm" },
+  { name: "Hiking Pole MT500", decathlonRef: "8840581", weightG: 280, category: "Poles", brand: "Simond", notes: "Per stok, 100-130cm, compact 58cm" },
+  { name: "Hiking Pole MT500 All Season", decathlonRef: "8910014", weightG: 280, category: "Poles", brand: "Simond", notes: "Per stok, 105-135cm, compact 77cm" },
+  { name: "Hiking Pole MT500 Antishock", decathlonRef: "8810080", weightG: 245, category: "Poles", brand: "Simond", notes: "Per stok, 105-130cm, compact 59cm" },
+  { name: "Hiking Pole MT500 Cork", decathlonRef: "8869228", weightG: 238, category: "Poles", brand: "Simond", notes: "Per stok, 100-130cm, compact 56cm" },
+  { name: "Hiking Pole MT900", decathlonRef: "8810058", weightG: 275, category: "Poles", brand: "Simond", notes: "Per stok, 110-130cm, compact 38cm" },
+  { name: "Hiking Pole Komperdell Ridge Hiker", decathlonRef: "8827380", weightG: 280, category: "Poles", brand: "Komperdell", notes: "Per stok, 105-140cm, compact 64cm" },
+  { name: "Hiking Pole Black Diamond BD Vista FLZ", decathlonRef: "8910080", weightG: 284, category: "Poles", brand: "Black Diamond", notes: "Per stok, 110-125cm, compact 37cm" },
+  { name: "Hiking Pole Paar Sprint", decathlonRef: "8793383", weightG: 184, category: "Poles", brand: "Simond", notes: "Per stok, 110-130cm, compact 38.5cm" },
+  { name: "Hiking Pole Komperdell Zero Pro", decathlonRef: "9017579", weightG: 218, category: "Poles", brand: "Komperdell", notes: "Per stok, 105-140cm, compact 64cm" },
+
+  // ---- TRAVEL BACKPACKS (Quechua) ----
+  { name: "Travel Pack 500 Organizer 30L", decathlonRef: "8990286", weightG: 1400, category: "Pack", brand: "Quechua", notes: "Reisrugzak 30L, 50x30x22cm" },
+  { name: "Travel Pack 500 Organizer 40L", decathlonRef: "8787845", weightG: 1400, category: "Pack", brand: "Quechua", notes: "Reisrugzak 40L" },
+  { name: "Travel Pack 900 Easy-Fit 50L (Men)", decathlonRef: "8880000", weightG: 2160, category: "Pack", brand: "Quechua", notes: "Reisrugzak 50L heren, 60x32x32cm" },
+  { name: "Travel Pack 900 Easy-Fit 50L (Women)", decathlonRef: "8816394", weightG: 2160, category: "Pack", brand: "Quechua", notes: "Reisrugzak 50L dames, 65x32x32cm" },
+  { name: "Travel Pack 900 Easy-Fit 70L (Men)", decathlonRef: "8880014", weightG: 2350, category: "Pack", brand: "Quechua", notes: "Reisrugzak 70L heren, 75x35x30cm" },
+  { name: "Travel Pack 900 Easy-Fit 60L (Women)", decathlonRef: "8880010", weightG: 2350, category: "Pack", brand: "Quechua", notes: "Reisrugzak 60L dames, 70x35x30cm" },
+
+  // ---- BIVAK/CAMP LIGHTS (Quechua) ----
+  { name: "Camp Light BL 40 lm (battery)", decathlonRef: "8615283", weightG: null, category: "Lighting", brand: "Quechua", notes: "40 lm, 3 AAA, 50u" },
+  { name: "Camp Light BL 100 lm (battery)", decathlonRef: "8492468", weightG: null, category: "Lighting", brand: "Quechua", notes: "100 lm, 4 AAA, 26.5u" },
+  { name: "Camp Light BL 60 lm (USB/dynamo)", decathlonRef: "8755548", weightG: null, category: "Lighting", brand: "Quechua", notes: "60 lm, USB-C/dynamo, 6.5u" },
+  { name: "Camp Light BL 100 lm (USB)", decathlonRef: "8670110", weightG: null, category: "Lighting", brand: "Quechua", notes: "100 lm, Micro-USB, 8u" },
+  { name: "Camp Light BL 120 lm", decathlonRef: "8881742", weightG: null, category: "Lighting", brand: "Quechua", notes: "120 lm, USB-C, 10u" },
+  { name: "Camp Light BL 200 lm", decathlonRef: "8852787", weightG: null, category: "Lighting", brand: "Quechua", notes: "200 lm, USB-C, 7u" },
+  { name: "Camp Light BL 230 lm", decathlonRef: "8492469", weightG: null, category: "Lighting", brand: "Quechua", notes: "230 lm, USB-C, 4u" },
+  { name: "Camp Light BL 400 lm", decathlonRef: "8492095", weightG: null, category: "Lighting", brand: "Quechua", notes: "400 lm, USB-C, 3.5u" },
+  { name: "Camp Light Lichtsnoer 200 lm", decathlonRef: "8649378", weightG: null, category: "Lighting", brand: "Quechua", notes: "200 lm, USB-C, 6u" },
+  { name: "Flashlight TL 100", decathlonRef: "8948415", weightG: null, category: "Lighting", brand: "Quechua", notes: "100 lm, Batteries" },
+  { name: "Flashlight 500 zoom", decathlonRef: "8501304", weightG: null, category: "Lighting", brand: "Quechua", notes: "500 lm, Batteries" },
+  { name: "Flashlight Dynamo 100", decathlonRef: "8665145", weightG: null, category: "Lighting", brand: "Quechua", notes: "15 lm, Dynamo" },
+  { name: "Flashlight Dynamo 500", decathlonRef: "8665147", weightG: null, category: "Lighting", brand: "Quechua", notes: "150 lm, Dynamo+USB" },
+  { name: "Flashlight Dynamo 900 PWB", decathlonRef: "8665150", weightG: null, category: "Lighting", brand: "Quechua", notes: "210 lm, Dynamo+USB" },
+  { name: "Flashlight 900 lumen", decathlonRef: "8501305", weightG: null, category: "Lighting", brand: "Quechua", notes: "900 lm, Micro-USB" },
+
+  // ---- HEADLAMPS (Quechua + Simond) ----
+  { name: "Headlamp HL50 LM", decathlonRef: "8786370", weightG: 80, category: "Lighting", brand: "Quechua", notes: "50 lm, 2 AAA, 20m" },
+  { name: "Headlamp Onnight 100 80 LM", decathlonRef: "8384891", weightG: 80, category: "Lighting", brand: "Quechua", notes: "80 lm, 3 AAA, 25m" },
+  { name: "Headlamp HL100 USB", decathlonRef: "8505882", weightG: 72, category: "Lighting", brand: "Quechua", notes: "120 lm, Micro-USB, 25m" },
+  { name: "Headlamp HL500", decathlonRef: "8919550", weightG: 90, category: "Lighting", brand: "Simond", notes: "500 lm, USB-C, 65m" },
+  { name: "Headlamp HL900", decathlonRef: "8979230", weightG: 105, category: "Lighting", brand: "Simond", notes: "900 lm, Batteries+USB-C, 120m" },
+  { name: "Headlamp Petzl Actik Core 550", decathlonRef: "8511135", weightG: 88, category: "Lighting", brand: "Petzl", notes: "625 lm, USB-C, 115m" },
+  { name: "Headlamp ML 200", decathlonRef: "8978237", weightG: 74, category: "Lighting", brand: "Simond", notes: "200 lm, USB-C, 30m" },
+  { name: "Headlamp UL 200", decathlonRef: "8787287", weightG: 42, category: "Lighting", brand: "Simond", notes: "200 lm, USB-C, 70m" },
+  { name: "Headlamp Sprint 400", decathlonRef: "8858783", weightG: 105, category: "Lighting", brand: "Simond", notes: "400 lm, USB-C, 85m" },
+  { name: "Headlamp Sprint 900", decathlonRef: "8813317", weightG: 139, category: "Lighting", brand: "Simond", notes: "900 lm, Micro-USB, 150m" },
+  { name: "Headlamp Petzl Swift RL", decathlonRef: "9012843", weightG: 102, category: "Lighting", brand: "Petzl", notes: "1100 lm, USB-C, 165m" },
+  { name: "Headlamp Petzl Swift LT", decathlonRef: "9012845", weightG: 43, category: "Lighting", brand: "Petzl", notes: "380 lm, USB-C, 30m" },
+];
+
+// ---------------------------------------------------------------------------
+// MAIN
+// ---------------------------------------------------------------------------
+async function main() {
+  const uri = process.env.MONGO_URI;
+  const dbName = process.env.MONGO_DB_NAME;
+  if (!uri || !dbName) {
+    console.error("Missing MONGO_URI or MONGO_DB_NAME");
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri, { dbName: "TrekList" });
+  console.log("Connected to DB:", mongoose.connection.name);
+
+  // 1. Fetch all Decathlon-brand CatalogItems
+  const DECATHLON_BRANDS = ["forclaz", "quechua", "simond", "decathlon"];
+  const catalogItems = await CatalogItem.find({
+    $or: [
+      { brandLC: { $in: DECATHLON_BRANDS } },
+    ],
+  }).lean();
+
+  // 2. Also fetch any awin offers linked to catalog items to enrich data
+  const catalogItemIds = catalogItems.map((ci) => ci._id);
+  const awinOffers = await MerchantOffer.find({
+    network: "awin",
+    productId: { $in: catalogItemIds },
+  }).lean();
+
+  // Build a map: productId -> [offers]
+  const offersByProductId = {};
+  for (const offer of awinOffers) {
+    const key = offer.productId.toString();
+    if (!offersByProductId[key]) offersByProductId[key] = [];
+    offersByProductId[key].push(offer);
+  }
+
+  console.log(`Found ${catalogItems.length} Decathlon catalog items`);
+  console.log(`Found ${awinOffers.length} linked awin offers`);
+
+  // 3. Build Excel workbook
+  const wb = new ExcelJS.Workbook();
+  wb.creator = "TrekList Export";
+  wb.created = new Date();
+
+  // ---- Sheet 1: Current DB Items ----
+  const dbSheet = wb.addWorksheet("DB Items (Decathlon)");
+  dbSheet.columns = [
+    { header: "DB ID", key: "dbId", width: 26 },
+    { header: "Name", key: "name", width: 40 },
+    { header: "Brand", key: "brand", width: 16 },
+    { header: "Model Number", key: "modelNumber", width: 20 },
+    { header: "Category", key: "category", width: 18 },
+    { header: "Subcategory", key: "subcategory", width: 18 },
+    { header: "Item Type", key: "itemType", width: 24 },
+    { header: "Weight (g)", key: "weightGrams", width: 12 },
+    { header: "Attributes", key: "attributes", width: 50 },
+    { header: "Canonical SKU", key: "canonicalSku", width: 18 },
+    { header: "Item Group ID", key: "itemGroupId", width: 18 },
+    { header: "EAN", key: "ean", width: 16 },
+    { header: "Has Awin Offer", key: "hasAwin", width: 14 },
+    { header: "Awin Merchant(s)", key: "awinMerchants", width: 30 },
+    { header: "Awin Region(s)", key: "awinRegions", width: 18 },
+    { header: "Active", key: "isActive", width: 10 },
+    { header: "Image Count", key: "imageCount", width: 12 },
+    { header: "Created", key: "createdAt", width: 20 },
+  ];
+
+  // Style header row
+  dbSheet.getRow(1).font = { bold: true };
+  dbSheet.getRow(1).fill = {
+    type: "pattern",
+    pattern: "solid",
+    fgColor: { argb: "FF4472C4" },
+  };
+  dbSheet.getRow(1).font = { bold: true, color: { argb: "FFFFFFFF" } };
+
+  for (const item of catalogItems) {
+    const idStr = item._id.toString();
+    const offers = offersByProductId[idStr] || [];
+    const merchants = [...new Set(offers.map((o) => o.merchantName || o.merchantId))].join(", ");
+    const regions = [...new Set(offers.map((o) => o.region))].join(", ");
+    const attrStr = item.attributes
+      ? Object.entries(item.attributes)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join(" | ")
+      : "";
+
+    dbSheet.addRow({
+      dbId: idStr,
+      name: item.name,
+      brand: item.brand || "",
+      modelNumber: item.modelNumber || "",
+      category: item.category || "",
+      subcategory: item.subcategory || "",
+      itemType: item.itemType || "",
+      weightGrams: item.weightGrams ?? "",
+      attributes: attrStr,
+      canonicalSku: item.canonicalSku || "",
+      itemGroupId: item.itemGroupId || "",
+      ean: item.externalIds?.ean || "",
+      hasAwin: offers.length > 0 ? "YES" : "NO",
+      awinMerchants: merchants,
+      awinRegions: regions,
+      isActive: item.isActive ? "YES" : "NO",
+      imageCount: (item.imageUrls || []).length,
+      createdAt: item.createdAt ? item.createdAt.toISOString().split("T")[0] : "",
+    });
+  }
+
+  // Zebra stripe
+  dbSheet.eachRow((row, rowNumber) => {
+    if (rowNumber > 1 && rowNumber % 2 === 0) {
+      row.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFF2F2F2" } };
+    }
+  });
+
+  // ---- Sheet 2: Image Products ----
+  const imgSheet = wb.addWorksheet("Products from Photos");
+  imgSheet.columns = [
+    { header: "Name", key: "name", width: 45 },
+    { header: "Decathlon Ref", key: "decathlonRef", width: 16 },
+    { header: "Brand", key: "brand", width: 16 },
+    { header: "Weight (g)", key: "weightG", width: 12 },
+    { header: "Category", key: "category", width: 18 },
+    { header: "Notes", key: "notes", width: 50 },
+    { header: "In DB?", key: "inDb", width: 10 },
+    { header: "DB Match Name", key: "dbMatchName", width: 45 },
+    { header: "DB ID", key: "dbId", width: 26 },
+  ];
+  imgSheet.getRow(1).font = { bold: true };
+  imgSheet.getRow(1).fill = {
+    type: "pattern", pattern: "solid", fgColor: { argb: "FF70AD47" },
+  };
+  imgSheet.getRow(1).font = { bold: true, color: { argb: "FFFFFFFF" } };
+
+  // Build lookup sets for matching: by canonicalSku, modelNumber, externalIds.ean, externalIds.sku, itemGroupId
+  const dbRefSet = new Set();
+  const dbRefToItem = {};
+  for (const item of catalogItems) {
+    const refs = [
+      item.canonicalSku,
+      item.modelNumber,
+      item.externalIds?.ean,
+      item.externalIds?.sku,
+      item.externalIds?.mpn,
+      item.itemGroupId,
+    ].filter(Boolean).map(String);
+    for (const r of refs) {
+      dbRefSet.add(r.trim());
+      dbRefToItem[r.trim()] = item;
+    }
+  }
+
+  // ---- Sheet 3: NOT in DB (the gap list) ----
+  const missingSheet = wb.addWorksheet("NOT in DB (Add These)");
+  missingSheet.columns = [
+    { header: "Name", key: "name", width: 45 },
+    { header: "Decathlon Ref", key: "decathlonRef", width: 16 },
+    { header: "Brand", key: "brand", width: 16 },
+    { header: "Weight (g)", key: "weightG", width: 12 },
+    { header: "Category", key: "category", width: 18 },
+    { header: "Notes", key: "notes", width: 50 },
+  ];
+  missingSheet.getRow(1).font = { bold: true };
+  missingSheet.getRow(1).fill = {
+    type: "pattern", pattern: "solid", fgColor: { argb: "FFFF0000" },
+  };
+  missingSheet.getRow(1).font = { bold: true, color: { argb: "FFFFFFFF" } };
+
+  let missingCount = 0;
+
+  for (const prod of IMAGE_PRODUCTS) {
+    const ref = (prod.decathlonRef || "").trim();
+    let match = null;
+    if (ref && dbRefSet.has(ref)) {
+      match = dbRefToItem[ref];
+    }
+
+    // Also try loose name-based match as fallback
+    if (!match && prod.name) {
+      const lowerName = prod.name.toLowerCase();
+      match = catalogItems.find(
+        (ci) =>
+          ci.name && ci.name.toLowerCase().includes(lowerName.split(" ").slice(-1)[0])
+      );
+    }
+
+    const inDb = !!match;
+
+    imgSheet.addRow({
+      name: prod.name,
+      decathlonRef: prod.decathlonRef,
+      brand: prod.brand,
+      weightG: prod.weightG ?? "",
+      category: prod.category,
+      notes: prod.notes,
+      inDb: inDb ? "YES" : "NO",
+      dbMatchName: match ? match.name : "",
+      dbId: match ? match._id.toString() : "",
+    });
+
+    // Color the "In DB?" cell
+    const lastRow = imgSheet.lastRow;
+    const inDbCell = lastRow.getCell("inDb");
+    inDbCell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: inDb ? "FFC6EFCE" : "FFFFC7CE" },
+    };
+
+    if (!inDb) {
+      missingSheet.addRow({
+        name: prod.name,
+        decathlonRef: prod.decathlonRef,
+        brand: prod.brand,
+        weightG: prod.weightG ?? "",
+        category: prod.category,
+        notes: prod.notes,
+      });
+      missingCount++;
+    }
+  }
+
+  // Zebra for missing sheet
+  missingSheet.eachRow((row, rowNumber) => {
+    if (rowNumber > 1 && rowNumber % 2 === 0) {
+      row.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFFFF0F0" } };
+    }
+  });
+
+  // ---- Summary sheet ----
+  const summarySheet = wb.addWorksheet("Summary");
+  summarySheet.columns = [
+    { header: "Metric", key: "metric", width: 40 },
+    { header: "Value", key: "value", width: 20 },
+  ];
+  summarySheet.getRow(1).font = { bold: true };
+  summarySheet.addRows([
+    { metric: "Decathlon items in DB", value: catalogItems.length },
+    { metric: "Items with awin offers", value: Object.keys(offersByProductId).length },
+    { metric: "Total items extracted from photos", value: IMAGE_PRODUCTS.length },
+    { metric: "Items from photos NOT in DB", value: missingCount },
+    { metric: "Items from photos already in DB", value: IMAGE_PRODUCTS.length - missingCount },
+    { metric: "Export date", value: new Date().toISOString().split("T")[0] },
+  ]);
+
+  // Save
+  const outPath = path.join(
+    process.env.HOME,
+    "Desktop",
+    "decathlon_items_export.xlsx"
+  );
+  await wb.xlsx.writeFile(outPath);
+  console.log(`\nExport written to: ${outPath}`);
+  console.log(`  DB Items sheet:       ${catalogItems.length} rows`);
+  console.log(`  Photo products sheet: ${IMAGE_PRODUCTS.length} rows`);
+  console.log(`  NOT in DB sheet:      ${missingCount} rows`);
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Admin gear catalog table: item name is now clickable, opens a read-only ViewCatalogItemModal showing image, type, brand, weight, attributes, description, and all affiliate links across all regions
- Add export-decathlon-items.js: exports Decathlon DB items to Excel and cross-references against in-store photo product list
- Add bulk-import-decathlon.js: two-phase import (ref lookup + name fallback) for Decathlon awin products with brand-safety filter, negative-lookahead keyword matching, and awin-ID dedup guard
- Install exceljs for Excel export