### PR TITLE
seo: serve sitemap via edge function instead of redirect proxy

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -15,17 +15,14 @@
   path = "/community/*"
   function = "community-meta"
 
+[[edge_functions]]
+  path = "/sitemap.xml"
+  function = "sitemap"
+
 # Proxy API calls to your Render API subdomain
 [[redirects]]
   from = "/api/*"
   to = "https://api.treklist.co/api/:splat"
-  status = 200
-  force = true
-
-# Dynamic sitemap served from the API (auto-includes new communities)
-[[redirects]]
-  from = "/sitemap.xml"
-  to = "https://api.treklist.co/sitemap.xml"
   status = 200
   force = true
 

--- a/client/netlify/edge-functions/sitemap.js
+++ b/client/netlify/edge-functions/sitemap.js
@@ -1,0 +1,17 @@
+export default async function handler(request, context) {
+  const response = await fetch('https://api.treklist.co/sitemap.xml');
+
+  if (!response.ok) {
+    return new Response('Error fetching sitemap', { status: 502 });
+  }
+
+  const xml = await response.text();
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      'content-type': 'application/xml; charset=utf-8',
+      'cache-control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}


### PR DESCRIPTION
Netlify's status=200 redirect proxy was being bypassed by the SPA fallback. Edge functions run before all other routing, guaranteeing the sitemap is served from the API.