### PR TITLE
seo: add share pages to treklist.co sitemap via API fetch

### DIFF
--- a/server/src/routes/publicShare.js
+++ b/server/src/routes/publicShare.js
@@ -657,4 +657,16 @@ router.post("/:token/copy", auth, async (req, res) => {
   }
 });
 
+// GET /api/public/share-tokens — returns all active share tokens for sitemap generation
+router.get("/share-tokens", async (req, res) => {
+  try {
+    const ShareToken = require("../models/ShareToken");
+    const tokens = await ShareToken.find({ revokedAt: null }).select("token").lean();
+    res.json(tokens.map((t) => t.token));
+  } catch (err) {
+    console.error("GET /api/public/share-tokens failed:", err);
+    res.status(500).json({ error: "Internal error" });
+  }
+});
+
 module.exports = router;

--- a/web/src/app/sitemap.js
+++ b/web/src/app/sitemap.js
@@ -1,8 +1,11 @@
 const BASE = 'https://treklist.co';
+const APP_BASE = 'https://app.treklist.co';
 const LOCALES = ['de', 'es', 'fr', 'it', 'nl'];
 const LEGAL = ['privacy', 'terms', 'cookies', 'affiliate-disclosure', 'imprint'];
 
-export default function sitemap() {
+export const revalidate = 3600;
+
+export default async function sitemap() {
   const home = [
     { url: BASE, lastModified: new Date(), changeFrequency: 'monthly', priority: 1 },
     ...LOCALES.map((locale) => ({
@@ -20,5 +23,22 @@ export default function sitemap() {
     priority: 0.3,
   }));
 
-  return [...home, ...legal];
+  let sharePages = [];
+  try {
+    const res = await fetch('https://api.treklist.co/api/public/share-tokens', {
+      next: { revalidate: 3600 },
+    });
+    if (res.ok) {
+      const tokens = await res.json();
+      sharePages = tokens.map((token) => ({
+        url: `${APP_BASE}/share/${token}/`,
+        changeFrequency: 'weekly',
+        priority: 0.8,
+      }));
+    }
+  } catch (_) {
+    // non-fatal — sitemap still serves static pages if API is unavailable
+  }
+
+  return [...home, ...legal, ...sharePages];
 }


### PR DESCRIPTION
Google can't reach api.treklist.co or app.treklist.co directly. Add a /api/public/share-tokens endpoint and fetch it from the Next.js sitemap (which Google already reads successfully) so all shared lists are discoverable from treklist.co/sitemap.xml.