### PR TITLE
fix: atomically update URL params when switching community from sidebar

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -746,7 +746,15 @@ export default function Dashboard() {
             onOpenMyGear={() => setActivePane("myGear")}
             onShowGearPane={() => setActivePane("lists")}
             onOpenTemplates={() => { setActivePane("templates"); setTemplatesKey((k) => k + 1); }}
-            onOpenCommunity={(slug) => { setActiveCommunitySlug(slug || null); setActiveCommunityPostId(null); setActivePane("community"); }}
+            onOpenCommunity={(slug) => {
+              setSearchParams((prev) => {
+                const next = new URLSearchParams(prev);
+                next.set("pane", "community");
+                if (slug) next.set("communitySlug", slug); else next.delete("communitySlug");
+                next.delete("communityPost");
+                return next;
+              }, { replace: true });
+            }}
             onSelectList={handleSelectList}
             onRefresh={fetchFullData}
             isLocked={fullData.list?.isLocked || false}


### PR DESCRIPTION
Multiple separate setSearchParams calls each read stale location.search, so later calls overwrote the slug change made by the first. Consolidate into a single call so all params compose correctly.