### PR TITLE
fix: stop tour onEnter re-firing on every render on mobile

### DIFF
--- a/client/src/components/TourModal.jsx
+++ b/client/src/components/TourModal.jsx
@@ -1,5 +1,5 @@
 // client/src/components/TourModal.jsx
-import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FiX } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
 
@@ -148,6 +148,13 @@ export default function TourModal({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isOpen, onSkip, onNext, onBack]);
 
+  // Keep a ref to steps so the onEnter/onExit effect only fires on actual step
+  // changes, not on every Dashboard re-render that recreates the tourSteps array.
+  const stepsRef = useRef(steps);
+  useLayoutEffect(() => {
+    stepsRef.current = steps;
+  }, [steps]);
+
   // Run step enter/exit hooks (for things like opening/closing sidebar on mobile)
   useEffect(() => {
     if (!isOpen) return;
@@ -155,8 +162,8 @@ export default function TourModal({
     const isMobile = () =>
       typeof window !== "undefined" && window.innerWidth < 640;
 
-    const prev = steps?.[stepIndex - 1];
-    const next = steps?.[stepIndex];
+    const prev = stepsRef.current?.[stepIndex - 1];
+    const next = stepsRef.current?.[stepIndex];
 
     try {
       prev?.onExit?.({ isMobile: isMobile() });
@@ -165,7 +172,8 @@ export default function TourModal({
     try {
       next?.onEnter?.({ isMobile: isMobile() });
     } catch {}
-  }, [isOpen, stepIndex, steps]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, stepIndex]);
 
   // Force a re-measure shortly after step changes
   useEffect(() => {

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 // src/pages/Dashboard.jsx
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import api from "../services/api";
 import { useParams, useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
@@ -98,12 +98,12 @@ export default function Dashboard() {
   const [isTourOpen, setIsTourOpen] = useState(false);
   const [tourStep, setTourStep] = useState(0);
 
-  const tourSteps = [
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tourSteps = useMemo(() => [
     {
       title: t("tour.steps.welcome.title"),
       body: t("tour.steps.welcome.body"),
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(false); // open sidebar
       },
     },
@@ -112,7 +112,6 @@ export default function Dashboard() {
       body: t("tour.steps.lists.body"),
       target: '[data-tour="sidebar-lists-header"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(false); // keep open
       },
     },
@@ -121,7 +120,6 @@ export default function Dashboard() {
       body: t("tour.steps.categories.body"),
       target: '[data-tour="gearlist-category"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // close sidebar
       },
     },
@@ -130,7 +128,6 @@ export default function Dashboard() {
       body: t("tour.steps.addCategory.body"),
       target: '[data-tour="gearlist-add-category"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
@@ -139,7 +136,6 @@ export default function Dashboard() {
       body: t("tour.steps.addItems.body"),
       target: '[data-tour="category-add-item"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
@@ -150,7 +146,6 @@ export default function Dashboard() {
       spotlightRadius: "8px",
       spotlightPadding: 10,
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
@@ -161,7 +156,6 @@ export default function Dashboard() {
       spotlightRadius: "8px",
       spotlightPadding: 10,
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
@@ -172,7 +166,6 @@ export default function Dashboard() {
       spotlightRadius: "8px",
       spotlightPadding: 10,
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
@@ -181,7 +174,6 @@ export default function Dashboard() {
       body: t("tour.steps.templates.body"),
       target: '[data-tour="sidebar-templates"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(false); // open sidebar
       },
     },
@@ -190,7 +182,6 @@ export default function Dashboard() {
       body: t("tour.steps.myGear.body"),
       target: '[data-tour="sidebar-my-gear"]',
       onEnter: ({ isMobile }) => {
-        setActivePane("gear");
         if (isMobile) setSidebarCollapsed(false); // open sidebar so the link is visible
       },
     },
@@ -212,7 +203,6 @@ export default function Dashboard() {
       spotlightRadius: "8px",
       spotlightPadding: 10,
       onEnter: ({ isMobile }) => {
-        setActivePane("myGear");
         if (isMobile) setSidebarCollapsed(true);
       },
     },
@@ -225,7 +215,9 @@ export default function Dashboard() {
         if (isMobile) setSidebarCollapsed(true); // keep closed
       },
     },
-  ];
+  // Re-create only when language changes (t), not on every render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [t]);
 
   const markTourSeen = useCallback(async () => {
     try {


### PR DESCRIPTION
setActivePane("gear") inside onEnter used setSearchParams (since 798ea56), which triggered a URL navigation even when the pane hadn't changed. This caused Dashboard to re-render on every tour step, which recreated tourSteps, which caused TourModal's onEnter effect to re-fire — creating a loop that raced against setSidebarCollapsed, leaving the sidebar in the wrong state.

Fixes:
- Remove setActivePane("gear") from every onEnter that wasn't changing panes (only myGearView→"myGear" and settings→"gear" actually need it)
- Memoize tourSteps so the array is stable across renders
- Use a stepsRef in TourModal so the onEnter effect only fires when stepIndex changes, not when the steps prop reference changes

Resolves: sidebar stays open at step 3, sidebar doesn't always open at step 9, sidebar stays open at step 11 on mobile.