### PR TITLE
feat: send admin email alerts for all community activity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ SMTP_PORT=465
 SMTP_USER=example@gmail.com
 SMTP_PASS=your_app_password
 
+# Admin email — receives alerts for all community posts, comments, and upvotes
+ADMIN_ACTIVITY_EMAIL=talljoe@treklist.co
+
 # Token expirations (in seconds)
 VERIFICATION_TOKEN_EXP=86400    # 24 hours
 RESET_TOKEN_EXP=3600            # 1 hour

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -16,6 +16,8 @@ const {
 } = require("../middleware/rateLimiters");
 const { detectLanguage } = require("../utils/googleTranslate");
 
+const ADMIN_ACTIVITY_EMAIL = process.env.ADMIN_ACTIVITY_EMAIL || "talljoe@treklist.co";
+
 const NOTIFICATION_EMAIL_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
 
 function buildNotificationUnsubscribeUrl(userId) {
@@ -159,6 +161,15 @@ router.post("/", authMiddleware, communityCommentLimiter, async (req, res) => {
 
     await comment.populate("userId", "trailname");
 
+    // Fire-and-forget admin activity email
+    const commentPostUrl = `https://app.treklist.co/community/post/${post._id}`;
+    sendSupportEmail({
+      to: ADMIN_ACTIVITY_EMAIL,
+      subject: `New comment on: ${post.title}`,
+      text: `${comment.userId.trailname} commented on "${post.title}".\n\nComment: ${comment.body.slice(0, 300)}\n\nView post: ${commentPostUrl}`,
+      html: `<p><strong>${comment.userId.trailname}</strong> commented on <strong>${post.title}</strong>.</p><p>${comment.body.slice(0, 300)}</p><p><a href="${commentPostUrl}">View post</a></p>`,
+    }).catch((e) => console.error("Admin new comment email error:", e));
+
     // Fire-and-forget notifications
     if (!parentCommentId) {
       if (post.userId.toString() !== req.userId) {
@@ -283,6 +294,20 @@ router.post("/:commentId/upvote", authMiddleware, communityUpvoteLimiter, async 
         commentId: comment._id,
       }).catch((e) => console.error("Upvote comment notification error:", e));
     }
+
+    // Fire-and-forget admin activity email
+    const commentUpvoteUrl = `https://app.treklist.co/community/post/${comment.postId}`;
+    Promise.all([
+      User.findById(req.userId).select("trailname").lean(),
+      Post.findById(comment.postId).select("title").lean(),
+    ]).then(([actor, commentPost]) => {
+      sendSupportEmail({
+        to: ADMIN_ACTIVITY_EMAIL,
+        subject: `Comment upvoted on: ${commentPost?.title || "a post"}`,
+        text: `${actor?.trailname || req.userId} upvoted a comment.\n\nComment: ${comment.body?.slice(0, 200)}\n\nView post: ${commentUpvoteUrl}`,
+        html: `<p><strong>${actor?.trailname || req.userId}</strong> upvoted a comment.</p><p>${comment.body?.slice(0, 200)}</p><p><a href="${commentUpvoteUrl}">View post</a></p>`,
+      }).catch((e) => console.error("Admin upvote comment email error:", e));
+    }).catch(() => {});
 
     res.json({ upvoted: true, upvoteCount: updated.upvoteCount });
   } catch (err) {

--- a/server/src/routes/posts.js
+++ b/server/src/routes/posts.js
@@ -17,6 +17,8 @@ const {
 const { detectLanguage } = require("../utils/googleTranslate");
 const { sendSupportEmail } = require("../utils/mailer");
 
+const ADMIN_ACTIVITY_EMAIL = process.env.ADMIN_ACTIVITY_EMAIL || "talljoe@treklist.co";
+
 const PAGE_SIZE = 20;
 
 // Only allow the tags Tiptap's StarterKit can produce — no attributes
@@ -115,6 +117,15 @@ router.post("/:slug/posts", authMiddleware, communityPostLimiter, async (req, re
     });
     await post.save();
     await post.populate("userId", "trailname");
+
+    const postUrl = `https://app.treklist.co/community/post/${post._id}`;
+    sendSupportEmail({
+      to: ADMIN_ACTIVITY_EMAIL,
+      subject: `New community post: ${post.title}`,
+      text: `${post.userId.trailname} posted in ${community.name}.\n\nTitle: ${post.title}\n\nView post: ${postUrl}`,
+      html: `<p><strong>${post.userId.trailname}</strong> posted in <strong>${community.name}</strong>.</p><p><strong>${post.title}</strong></p><p><a href="${postUrl}">View post</a></p>`,
+    }).catch((e) => console.error("Admin new post email error:", e));
+
     res.status(201).json(post);
   } catch (err) {
     console.error("Create post error:", err);
@@ -280,6 +291,17 @@ router.post("/:postId/upvote", authMiddleware, communityUpvoteLimiter, async (re
         postId: post._id,
       }).catch((e) => console.error("Upvote notification error:", e));
     }
+
+    // Fire-and-forget admin activity email
+    const postUrlUpvote = `https://app.treklist.co/community/post/${post._id}`;
+    User.findById(req.userId).select("trailname").lean().then((actor) => {
+      sendSupportEmail({
+        to: ADMIN_ACTIVITY_EMAIL,
+        subject: `Post upvoted: ${post.title}`,
+        text: `${actor?.trailname || req.userId} upvoted a post.\n\nTitle: ${post.title}\n\nView post: ${postUrlUpvote}`,
+        html: `<p><strong>${actor?.trailname || req.userId}</strong> upvoted a post.</p><p><strong>${post.title}</strong></p><p><a href="${postUrlUpvote}">View post</a></p>`,
+      }).catch((e) => console.error("Admin upvote post email error:", e));
+    }).catch(() => {});
 
     res.json({ upvoted: true, upvoteCount: updated.upvoteCount });
   } catch (err) {


### PR DESCRIPTION
Fire-and-forget emails to talljoe@treklist.co on new posts, new comments, post upvotes, and comment upvotes. Address is overridable via ADMIN_ACTIVITY_EMAIL env var.