### PR TITLE
feat: match scanned photos against the catalog before custom creation

### DIFF
--- a/client/src/components/AddGearItemModal.jsx
+++ b/client/src/components/AddGearItemModal.jsx
@@ -34,6 +34,13 @@ export default function AddGearItemModal({ listId, categoryId, onClose, onAdded 
     [existingItems],
   );
 
+  // Catalog rows match on productId (catalog item id), not globalItem id.
+  // productId may be null on older items, so detection is best-effort.
+  const existingProductIds = useMemo(
+    () => new Set(existingItems.map((it) => it.productId).filter(Boolean).map(String)),
+    [existingItems],
+  );
+
   const computeStartPos = () => {
     const inCat = existingItems.filter(
       (it) => String(it.category) === String(categoryId),
@@ -130,6 +137,7 @@ export default function AddGearItemModal({ listId, categoryId, onClose, onAdded 
             showMyGear
             tabLayout
             existingGlobalIds={existingGlobalIds}
+            existingProductIds={existingProductIds}
             onConfirm={handleConfirm}
             onClose={onClose}
           />

--- a/client/src/components/PhotoScanModal.jsx
+++ b/client/src/components/PhotoScanModal.jsx
@@ -1,17 +1,18 @@
 // client/src/components/PhotoScanModal.jsx
-// AI vision gear scanner. Scan flow: capture/upload → /api/ai/scan-item
+// AI vision gear scanner. Scan flow: capture/upload → /api/ai/scan-item → catalog lookup
 import React, { useState, useRef } from "react";
-import { FiCamera, FiUpload, FiX, FiRefreshCw, FiCheck } from "react-icons/fi";
+import { FiCamera, FiUpload, FiX, FiRefreshCw } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
 import api from "../services/api";
 import { uploadGearItemPhoto } from "../services/cloudinaryUpload";
 import { downscaleImageFile } from "../utils/imageProcessing";
 
-export default function PhotoScanModal({ onResult, onClose }) {
+export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
   const { t } = useTranslation("common");
-  const [phase, setPhase] = useState("idle"); // idle | scanning | result | error
+  const [phase, setPhase] = useState("idle"); // idle | scanning | catalog-matches | error
   const [imagePreview, setImagePreview] = useState(null);
-  const [result, setResult] = useState(null);
+  const [scanData, setScanData] = useState(null);
+  const [catalogMatches, setCatalogMatches] = useState([]);
   const [errorMsg, setErrorMsg] = useState(null);
   const cameraInputRef = useRef(null);
   const uploadInputRef = useRef(null);
@@ -24,11 +25,30 @@ export default function PhotoScanModal({ onResult, onClose }) {
     try {
       const uploadPromise = uploadGearItemPhoto(dataUrl).catch(() => null);
       const scanPromise = api.post("/ai/scan-item", { image: dataUrl });
+      // Catalog lookup needs only the scan result, so chain it off the scan
+      // to overlap with the photo upload
+      const catalogPromise = scanPromise.then(async ({ data: scan }) => {
+        if (!scan.name) return [];
+        try {
+          const q = [scan.name, scan.brand].filter(Boolean).join(" ");
+          const { data: items } = await api.get("/catalog/items", { params: { q, limit: 4 } });
+          return items || [];
+        } catch {
+          return []; // catalog check is best-effort
+        }
+      });
 
-      const [{ data }, uploadResult] = await Promise.all([scanPromise, uploadPromise]);
+      const [{ data }, uploadResult, matches] = await Promise.all([scanPromise, uploadPromise, catalogPromise]);
       if (uploadResult?.secureUrl) data.photoUrl = uploadResult.secureUrl;
-      setResult(data);
-      setPhase("result");
+
+      if (matches.length > 0) {
+        setScanData(data);
+        setCatalogMatches(matches);
+        setPhase("catalog-matches");
+      } else {
+        // No catalog match — go straight to pre-filled custom form
+        onResult(data);
+      }
     } catch (err) {
       const msg = err.response?.data?.error || t("photoScanModal.errorFallback", "Scan failed. Try again or add manually.");
       setErrorMsg(msg);
@@ -54,7 +74,8 @@ export default function PhotoScanModal({ onResult, onClose }) {
   function reset() {
     setPhase("idle");
     setImagePreview(null);
-    setResult(null);
+    setScanData(null);
+    setCatalogMatches([]);
     setErrorMsg(null);
   }
 
@@ -120,51 +141,36 @@ export default function PhotoScanModal({ onResult, onClose }) {
             </div>
           )}
 
-          {/* Result */}
-          {phase === "result" && result && (
+          {/* Catalog matches */}
+          {phase === "catalog-matches" && (
             <div className="space-y-3">
-              {imagePreview && (
-                <img src={imagePreview} alt="" className="w-full h-32 object-cover rounded-lg" />
-              )}
-              <span className="inline-block text-xs px-2 py-0.5 rounded-full font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-                {t("photoScanModal.badgeVision", "AI Vision")}
-              </span>
-              <dl className="space-y-1.5 text-sm">
-                <div className="flex gap-2">
-                  <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldName", "Name")}</dt>
-                  <dd className="text-primary font-medium">{result.name}</dd>
-                </div>
-                {result.brand && (
-                  <div className="flex gap-2">
-                    <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldBrand", "Brand")}</dt>
-                    <dd className="text-primary">{result.brand}</dd>
-                  </div>
-                )}
-                {result.category && (
-                  <div className="flex gap-2">
-                    <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldCategory", "Category")}</dt>
-                    <dd className="text-primary">{result.category}</dd>
-                  </div>
-                )}
-                {result.itemType && (
-                  <div className="flex gap-2">
-                    <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldType", "Type")}</dt>
-                    <dd className="text-primary">{result.itemType}</dd>
-                  </div>
-                )}
-                {result.weightGrams != null && (
-                  <div className="flex gap-2">
-                    <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldWeight", "Weight")}</dt>
-                    <dd className="text-primary">{result.weightGrams}g</dd>
-                  </div>
-                )}
-                {result.description && (
-                  <div className="flex gap-2">
-                    <dt className="text-primary/40 w-16 flex-shrink-0 text-xs pt-0.5">{t("photoScanModal.fieldDesc", "Desc")}</dt>
-                    <dd className="text-primary/70 text-xs leading-relaxed">{result.description}</dd>
-                  </div>
-                )}
-              </dl>
+              <p className="text-xs text-primary/50 text-center">
+                {t("photoScanModal.catalogMatchHeading", "Found in catalog — is this your item?")}
+              </p>
+              <div className="space-y-2">
+                {catalogMatches.map((item) => {
+                  const thumb = item.imageUrls?.[0];
+                  return (
+                    <button
+                      key={item._id}
+                      onClick={() => onCatalogSelect(item)}
+                      className="w-full flex items-center gap-3 p-2 rounded-lg border border-base-300 hover:border-secondary/50 hover:bg-secondary/5 transition-colors text-left"
+                    >
+                      {thumb ? (
+                        <img src={thumb} alt="" className="w-10 h-10 object-cover rounded flex-shrink-0" />
+                      ) : (
+                        <div className="w-10 h-10 rounded bg-base-200 flex-shrink-0" />
+                      )}
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-primary truncate">{item.name}</p>
+                        {item.brand && (
+                          <p className="text-xs text-primary/50 truncate">{item.brand}</p>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           )}
 
@@ -180,7 +186,7 @@ export default function PhotoScanModal({ onResult, onClose }) {
         </div>
 
         {/* Footer */}
-        {(phase === "result" || phase === "error") && (
+        {(phase === "catalog-matches" || phase === "error") && (
           <div className="flex gap-2 px-4 pb-4">
             <button
               onClick={reset}
@@ -189,13 +195,12 @@ export default function PhotoScanModal({ onResult, onClose }) {
               <FiRefreshCw size={13} />
               {t("photoScanModal.tryAgain", "Try again")}
             </button>
-            {phase === "result" && (
+            {phase === "catalog-matches" && (
               <button
-                onClick={() => onResult(result)}
-                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm bg-secondary text-white rounded-lg hover:bg-secondary/90 font-medium transition-colors"
+                onClick={() => onResult(scanData)}
+                className="flex-1 flex items-center justify-center px-3 py-2 text-sm border border-base-300 rounded-lg text-primary/60 hover:text-primary transition-colors"
               >
-                <FiCheck size={14} />
-                {t("photoScanModal.useThisItem", "Use this item")}
+                {t("photoScanModal.noneOfThese", "None of these")}
               </button>
             )}
           </div>

--- a/client/src/components/PhotoScanModal.jsx
+++ b/client/src/components/PhotoScanModal.jsx
@@ -1,13 +1,14 @@
 // client/src/components/PhotoScanModal.jsx
 // AI vision gear scanner. Scan flow: capture/upload → /api/ai/scan-item → catalog lookup
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { FiCamera, FiUpload, FiX, FiRefreshCw } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
 import api from "../services/api";
 import { uploadGearItemPhoto } from "../services/cloudinaryUpload";
 import { downscaleImageFile } from "../utils/imageProcessing";
+import useStagedMessage from "../hooks/useStagedMessage";
 
-export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
+export default function PhotoScanModal({ onResult, onCatalogSelect, onClose, initialFile }) {
   const { t } = useTranslation("common");
   const [phase, setPhase] = useState("idle"); // idle | scanning | catalog-matches | error
   const [imagePreview, setImagePreview] = useState(null);
@@ -25,22 +26,11 @@ export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
     try {
       const uploadPromise = uploadGearItemPhoto(dataUrl).catch(() => null);
       const scanPromise = api.post("/ai/scan-item", { image: dataUrl });
-      // Catalog lookup needs only the scan result, so chain it off the scan
-      // to overlap with the photo upload
-      const catalogPromise = scanPromise.then(async ({ data: scan }) => {
-        if (!scan.name) return [];
-        try {
-          const q = [scan.name, scan.brand].filter(Boolean).join(" ");
-          const { data: items } = await api.get("/catalog/items", { params: { q, limit: 4 } });
-          return items || [];
-        } catch {
-          return []; // catalog check is best-effort
-        }
-      });
 
-      const [{ data }, uploadResult, matches] = await Promise.all([scanPromise, uploadPromise, catalogPromise]);
+      const [{ data }, uploadResult] = await Promise.all([scanPromise, uploadPromise]);
       if (uploadResult?.secureUrl) data.photoUrl = uploadResult.secureUrl;
 
+      const matches = data.catalogMatches || [];
       if (matches.length > 0) {
         setScanData(data);
         setCatalogMatches(matches);
@@ -50,16 +40,19 @@ export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
         onResult(data);
       }
     } catch (err) {
-      const msg = err.response?.data?.error || t("photoScanModal.errorFallback", "Scan failed. Try again or add manually.");
+      const code = err.response?.data?.error;
+      const msg =
+        code === "not_identified"
+          ? t("photoScanModal.errorNotIdentified", "Couldn't identify an item in this photo. Try a clearer shot of the packaging or label.")
+          : code === "rate_limited"
+            ? t("photoScanModal.errorRateLimited", "Too many scans — wait a minute and try again.")
+            : t("photoScanModal.errorFallback", "Scan failed. Try again or add manually.");
       setErrorMsg(msg);
       setPhase("error");
     }
   }
 
-  async function handleFileChange(e) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    e.target.value = "";
+  async function processFile(file) {
     try {
       const { blob } = await downscaleImageFile(file, { maxSize: 1600, quality: 0.85 });
       const reader = new FileReader();
@@ -70,6 +63,28 @@ export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
       setPhase("error");
     }
   }
+
+  function handleFileChange(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = "";
+    processFile(file);
+  }
+
+  // Scan immediately when opened with a pasted/dropped image
+  useEffect(() => {
+    if (initialFile) processFile(initialFile);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const scanningMsg = useStagedMessage(
+    phase === "scanning"
+      ? [
+          t("photoScanModal.scanningVision", "Identifying with AI…"),
+          t("photoScanModal.scanningMatching", "Matching against the catalog…"),
+        ]
+      : [],
+    3000,
+  );
 
   function reset() {
     setPhase("idle");
@@ -134,9 +149,7 @@ export default function PhotoScanModal({ onResult, onCatalogSelect, onClose }) {
               )}
               <div className="flex items-center justify-center gap-2 py-2">
                 <div className="w-4 h-4 border-2 border-secondary border-t-transparent rounded-full animate-spin" />
-                <span className="text-sm text-primary/60">
-                  {t("photoScanModal.scanningVision", "Identifying with AI…")}
-                </span>
+                <span className="text-sm text-primary/60">{scanningMsg}</span>
               </div>
             </div>
           )}

--- a/client/src/components/SmartItemSearch.jsx
+++ b/client/src/components/SmartItemSearch.jsx
@@ -365,7 +365,7 @@ export default function SmartItemSearch({
   showMyGear = true,
   excludeGlobalItemId = null,
   existingGlobalIds = new Set(),
-  existingProductIds = new Set(),
+  existingProductIds,
   onConfirm,
   onClose,
   tabLayout = false,
@@ -689,6 +689,15 @@ export default function SmartItemSearch({
     }
   };
 
+  // "Already added" detection for catalog rows: list contexts pass the list's
+  // productIds explicitly; everywhere else fall back to My Gear ownership
+  const effectiveProductIds = useMemo(
+    () =>
+      existingProductIds ??
+      new Set(myGearItems.map((i) => i.productId).filter(Boolean).map(String)),
+    [existingProductIds, myGearItems],
+  );
+
   // Inject catalog items into the results (optionally selecting one),
   // restoring the invariants the normal search flow maintains: exclusive
   // selection, no custom form, and the Import tab active.
@@ -699,7 +708,7 @@ export default function SmartItemSearch({
       return added.length ? [...added, ...prev] : prev;
     });
     // Never auto-select an item that's already in the list (row renders disabled)
-    const selectable = select && !existingProductIds.has(String(select._id));
+    const selectable = select && !effectiveProductIds.has(String(select._id));
     setCatalogSelected(selectable ? new Set([String(select._id)]) : new Set());
     setMyGearSelected(new Set());
     setCustomMode(null);
@@ -1174,7 +1183,7 @@ export default function SmartItemSearch({
                   onViewCatalogDetails={handleViewCatalogDetails}
                   multiSelect={multiSelect}
                   existingGlobalIds={existingGlobalIds}
-                  existingProductIds={existingProductIds}
+                  existingProductIds={effectiveProductIds}
                   loading={catalogLoading}
                 />
               )}
@@ -1356,6 +1365,9 @@ export default function SmartItemSearch({
           onCatalogSelect={(item) => {
             closeScanModal();
             selectCatalogItem(item);
+            // Show full details with an Import button — tapping a match should
+            // confirm, not just silently select in the background list
+            handleViewCatalogDetails(item);
           }}
         />
       )}

--- a/client/src/components/SmartItemSearch.jsx
+++ b/client/src/components/SmartItemSearch.jsx
@@ -847,15 +847,32 @@ export default function SmartItemSearch({
     <div
       className="flex flex-col h-full"
       onDragOver={(e) => {
-        if (e.dataTransfer?.types?.includes("Files")) e.preventDefault();
+        const types = e.dataTransfer?.types || [];
+        if (["Files", "text/uri-list", "text/plain"].some((t) => types.includes(t))) {
+          e.preventDefault();
+        }
       }}
       onDrop={(e) => {
+        // Dropped image → photo scan
         const file = [...(e.dataTransfer?.files || [])].find((f) =>
           f.type.startsWith("image/"),
         );
         if (file) {
           e.preventDefault();
           openScanWithFile(file);
+          return;
+        }
+        // Dropped link → same flow as pasting a URL
+        const raw =
+          e.dataTransfer?.getData("text/uri-list") || e.dataTransfer?.getData("text") || "";
+        const url = raw
+          .split("\n")
+          .map((l) => l.trim())
+          .find((l) => l && !l.startsWith("#"));
+        if (isUrl(url)) {
+          e.preventDefault();
+          setQuery(url);
+          handleCreateAction(url);
         }
       }}
     >

--- a/client/src/components/SmartItemSearch.jsx
+++ b/client/src/components/SmartItemSearch.jsx
@@ -629,6 +629,20 @@ export default function SmartItemSearch({
     }
   };
 
+  // Inject a catalog item into the results and select it, restoring the
+  // invariants the normal search flow maintains: exclusive selection, no
+  // custom form, and the Import tab active.
+  const selectCatalogItem = (item) => {
+    setCatalogResults((prev) => {
+      const ids = new Set(prev.map((i) => String(i._id)));
+      return ids.has(String(item._id)) ? prev : [item, ...prev];
+    });
+    setCatalogSelected(new Set([String(item._id)]));
+    setMyGearSelected(new Set());
+    setCustomMode(null);
+    if (tabLayout) setAndPersistTab("import");
+  };
+
   // Create action — runs AI fill, then either shows a catalog match or pre-fills the custom form
   const handleCreateAction = async (queryOverride) => {
     const inputQuery = (queryOverride !== undefined ? queryOverride : query).trim();
@@ -652,12 +666,7 @@ export default function SmartItemSearch({
         // Found in catalog — switch to Import tab and auto-select.
         // Do NOT update query here: changing it would re-trigger the debounced catalog
         // search, causing a loading spinner that wipes the result before the new fetch completes.
-        setCatalogResults((prev) => {
-          const ids = new Set(prev.map((i) => String(i._id)));
-          return ids.has(String(catalogMatch._id)) ? prev : [catalogMatch, ...prev];
-        });
-        setCatalogSelected(new Set([String(catalogMatch._id)]));
-        if (tabLayout) setAndPersistTab("import");
+        selectCatalogItem(catalogMatch);
       } else {
         // No catalog match — switch to Custom tab, only fill empty fields
         setCustomMode("ai");
@@ -1027,8 +1036,8 @@ export default function SmartItemSearch({
                 </>
               )}
 
-              {/* Catalog — shown when searching or category filter active */}
-              {hasSearchIntent && (
+              {/* Catalog — shown when searching, filtering, or holding an injected scan match */}
+              {(hasSearchIntent || catalogResults.length > 0) && (
                 <ResultSection
                   title={t("smartItemSearch.fromCatalog", "From Catalog")}
                   items={catalogResults}
@@ -1216,6 +1225,10 @@ export default function SmartItemSearch({
               link: "",
               imageUrl: scanData.photoUrl || scanData.imageUrl || "",
             });
+          }}
+          onCatalogSelect={(item) => {
+            setShowScanModal(false);
+            selectCatalogItem(item);
           }}
         />
       )}

--- a/client/src/components/SmartItemSearch.jsx
+++ b/client/src/components/SmartItemSearch.jsx
@@ -14,6 +14,7 @@ import Spinner from "./ui/Spinner";
 import LinkInput from "./LinkInput";
 import CatalogItemPreviewModal from "./CatalogItemPreviewModal";
 import PhotoScanModal from "./PhotoScanModal";
+import useStagedMessage from "../hooks/useStagedMessage";
 
 // key = translation lookup key; value = API filter value (must stay English)
 const CHIPS = [
@@ -94,8 +95,30 @@ function ItemRow({ item, selected, onToggle, onViewDetails, multiSelect, disable
   );
 }
 
+// ── AI lookup progress ────────────────────────────────────────────────────────
+function AiSearchProgress({ urlQuery }) {
+  const { t } = useTranslation("common");
+  const steps = urlQuery
+    ? [
+        t("smartItemSearch.aiProgress.reading", "Reading product page…"),
+        t("smartItemSearch.aiProgress.identifying", "Identifying the item…"),
+        t("smartItemSearch.aiProgress.matching", "Matching against the catalog…"),
+      ]
+    : [
+        t("smartItemSearch.aiProgress.identifying", "Identifying the item…"),
+        t("smartItemSearch.aiProgress.matching", "Matching against the catalog…"),
+      ];
+  const msg = useStagedMessage(steps, 2500);
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-2">
+      <FiLoader size={20} className="animate-spin text-secondary" />
+      <p className="text-sm text-primary/50">{msg}</p>
+    </div>
+  );
+}
+
 // ── Section (My Gear or Catalog) ──────────────────────────────────────────────
-function ResultSection({ title, items, type, myGearSelected, catalogSelected, onToggleMyGear, onToggleCatalog, onViewCatalogDetails, onViewMyGearDetails, multiSelect, existingGlobalIds, loading }) {
+function ResultSection({ title, items, type, myGearSelected, catalogSelected, onToggleMyGear, onToggleCatalog, onViewCatalogDetails, onViewMyGearDetails, multiSelect, existingGlobalIds, existingProductIds, loading }) {
   const { t } = useTranslation("common");
   if (loading) {
     return (
@@ -132,6 +155,7 @@ function ResultSection({ title, items, type, myGearSelected, catalogSelected, on
             const offer = item.offers?.[0];
             const priceLabel =
               offer?.price ? `$${offer.price} · ${offer.merchantName || ""}`.replace(/ · $/, "") : null;
+            const disabled = existingProductIds?.has(id);
             return (
               <ItemRow
                 key={id}
@@ -140,6 +164,8 @@ function ResultSection({ title, items, type, myGearSelected, catalogSelected, on
                 onToggle={onToggleCatalog}
                 onViewDetails={onViewCatalogDetails}
                 multiSelect={multiSelect}
+                disabled={disabled}
+                badge={disabled ? t("smartItemSearch.added", "Added") : null}
                 subLabel={item.itemType || item.subcategory || null}
                 priceLabel={priceLabel}
               />
@@ -339,6 +365,7 @@ export default function SmartItemSearch({
   showMyGear = true,
   excludeGlobalItemId = null,
   existingGlobalIds = new Set(),
+  existingProductIds = new Set(),
   onConfirm,
   onClose,
   tabLayout = false,
@@ -431,6 +458,19 @@ export default function SmartItemSearch({
 
   // Photo scan modal
   const [showScanModal, setShowScanModal] = useState(false);
+  const [scanFile, setScanFile] = useState(null); // pasted/dropped image to scan
+  const [showFilters, setShowFilters] = useState(false);
+
+  const closeScanModal = () => {
+    setShowScanModal(false);
+    setScanFile(null);
+  };
+
+  const openScanWithFile = (file) => {
+    if (!file) return;
+    setScanFile(file);
+    setShowScanModal(true);
+  };
 
   // Catalog item preview
   const [previewItem, setPreviewItem] = useState(null);
@@ -629,19 +669,24 @@ export default function SmartItemSearch({
     }
   };
 
-  // Inject a catalog item into the results and select it, restoring the
-  // invariants the normal search flow maintains: exclusive selection, no
-  // custom form, and the Import tab active.
-  const selectCatalogItem = (item) => {
+  // Inject catalog items into the results (optionally selecting one),
+  // restoring the invariants the normal search flow maintains: exclusive
+  // selection, no custom form, and the Import tab active.
+  const showCatalogMatches = (items, { select } = {}) => {
     setCatalogResults((prev) => {
       const ids = new Set(prev.map((i) => String(i._id)));
-      return ids.has(String(item._id)) ? prev : [item, ...prev];
+      const added = items.filter((m) => !ids.has(String(m._id)));
+      return added.length ? [...added, ...prev] : prev;
     });
-    setCatalogSelected(new Set([String(item._id)]));
+    // Never auto-select an item that's already in the list (row renders disabled)
+    const selectable = select && !existingProductIds.has(String(select._id));
+    setCatalogSelected(selectable ? new Set([String(select._id)]) : new Set());
     setMyGearSelected(new Set());
     setCustomMode(null);
     if (tabLayout) setAndPersistTab("import");
   };
+
+  const selectCatalogItem = (item) => showCatalogMatches([item], { select: item });
 
   // Create action — runs AI fill, then either shows a catalog match or pre-fills the custom form
   const handleCreateAction = async (queryOverride) => {
@@ -652,21 +697,19 @@ export default function SmartItemSearch({
     try {
       const { data } = await api.post("/ai/fill-item", { query: inputQuery });
 
-      // Search catalog with AI-extracted name + brand
-      let catalogMatch = null;
-      if (data.name) {
-        try {
-          const q = [data.name, data.brand].filter(Boolean).join(" ");
-          const { data: items } = await api.get("/catalog/items", { params: { q } });
-          if (items?.length > 0) catalogMatch = items[0];
-        } catch { /* ignore — catalog search is best-effort */ }
-      }
+      // The server matches the AI extraction against the catalog (with
+      // progressive fallback) and returns candidates on the response.
+      // Do NOT update query here: changing it would re-trigger the debounced catalog
+      // search, causing a loading spinner that wipes the result before the new fetch completes.
+      const matches = data.catalogMatches || [];
 
-      if (catalogMatch) {
-        // Found in catalog — switch to Import tab and auto-select.
-        // Do NOT update query here: changing it would re-trigger the debounced catalog
-        // search, causing a loading spinner that wipes the result before the new fetch completes.
-        selectCatalogItem(catalogMatch);
+      if (matches.length === 1) {
+        selectCatalogItem(matches[0]);
+        toast.success(t("smartItemSearch.toasts.catalogMatch", "Found in catalog"));
+      } else if (matches.length > 1) {
+        // Several plausible matches — let the user pick instead of guessing
+        showCatalogMatches(matches);
+        toast(t("smartItemSearch.toasts.catalogMatches", "Found possible matches — pick yours below"));
       } else {
         // No catalog match — switch to Custom tab, only fill empty fields
         setCustomMode("ai");
@@ -778,8 +821,34 @@ export default function SmartItemSearch({
     catalogResults.length === 0 &&
     !showingCustomForm;
 
+  // No dead ends: when a multi-word search finds nothing in My Gear or the
+  // catalog, look it up with AI automatically — once per query
+  const autoLookupRef = useRef("");
+  useEffect(() => {
+    const q = debouncedQuery.trim();
+    if (!hasNoResults || myGearLoading) return;
+    if (isUrl(q) || q.split(/\s+/).length < 2) return;
+    if (autoLookupRef.current === q.toLowerCase()) return;
+    autoLookupRef.current = q.toLowerCase();
+    handleCreateAction(q);
+  }, [hasNoResults, debouncedQuery, myGearLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <div className="flex flex-col h-full">
+    <div
+      className="flex flex-col h-full"
+      onDragOver={(e) => {
+        if (e.dataTransfer?.types?.includes("Files")) e.preventDefault();
+      }}
+      onDrop={(e) => {
+        const file = [...(e.dataTransfer?.files || [])].find((f) =>
+          f.type.startsWith("image/"),
+        );
+        if (file) {
+          e.preventDefault();
+          openScanWithFile(file);
+        }
+      }}
+    >
 
       {/* ── Tab row (tabLayout only) ───────────────────────────────────────── */}
       {tabLayout && (
@@ -823,7 +892,22 @@ export default function SmartItemSearch({
                   setQuery(e.target.value);
                   if (!tabLayout) setCustomMode(null);
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && query.trim() && !aiLoading) {
+                    e.preventDefault();
+                    handleCreateAction(query.trim());
+                  }
+                }}
                 onPaste={(e) => {
+                  // Screenshot paste (Cmd+V) → photo scan flow
+                  const imageItem = [...(e.clipboardData?.items || [])].find((i) =>
+                    i.type.startsWith("image/"),
+                  );
+                  if (imageItem) {
+                    e.preventDefault();
+                    openScanWithFile(imageItem.getAsFile());
+                    return;
+                  }
                   const pasted = (e.clipboardData?.getData("text") || "").trim();
                   if (isUrl(pasted)) {
                     handleCreateAction(pasted);
@@ -871,8 +955,26 @@ export default function SmartItemSearch({
             </p>
           )}
 
-          {/* Category / Subcategory / Brand dropdowns — tabLayout Import tab only */}
+          {/* Hint + browse toggle — tabLayout Import tab only */}
           {tabLayout && (
+            <div className="mt-1.5 flex items-center justify-between gap-2">
+              <p className="text-xs text-primary/35 truncate">
+                {!query
+                  ? t("smartItemSearch.tabSearchHint", "Type a name · Paste a link · Snap a photo")
+                  : " "}
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowFilters((v) => !v)}
+                className="text-xs text-primary/50 hover:text-primary/80 underline underline-offset-2 flex-shrink-0"
+              >
+                {t("smartItemSearch.browseToggle", "Browse categories")}
+              </button>
+            </div>
+          )}
+
+          {/* Category / Subcategory / Brand dropdowns — collapsed until Browse (or an active filter) */}
+          {tabLayout && (showFilters || categoryFilter || subcategoryFilter || brandFilter) && (
             <div className="mt-2 flex gap-1.5">
               <select
                 value={categoryFilter || ""}
@@ -996,12 +1098,7 @@ export default function SmartItemSearch({
               unitLabel={unitLabel}
             />
           ) : aiLoading ? (
-            <div className="flex flex-col items-center justify-center h-full gap-2">
-              <FiLoader size={20} className="animate-spin text-secondary" />
-              <p className="text-sm text-primary/50">
-                {t("smartItemSearch.aiSearching", "Searching with AI...")}
-              </p>
-            </div>
+            <AiSearchProgress urlQuery={isUrl(query)} />
           ) : hasNoResults ? (
             <NoResults
               query={debouncedQuery}
@@ -1049,6 +1146,7 @@ export default function SmartItemSearch({
                   onViewCatalogDetails={handleViewCatalogDetails}
                   multiSelect={multiSelect}
                   existingGlobalIds={existingGlobalIds}
+                  existingProductIds={existingProductIds}
                   loading={catalogLoading}
                 />
               )}
@@ -1210,9 +1308,10 @@ export default function SmartItemSearch({
       {/* Photo scan modal */}
       {showScanModal && (
         <PhotoScanModal
-          onClose={() => setShowScanModal(false)}
+          initialFile={scanFile}
+          onClose={closeScanModal}
           onResult={(scanData) => {
-            setShowScanModal(false);
+            closeScanModal();
             setCustomMode("ai");
             if (tabLayout) setAndPersistTab("custom");
             setCustomForm({
@@ -1227,7 +1326,7 @@ export default function SmartItemSearch({
             });
           }}
           onCatalogSelect={(item) => {
-            setShowScanModal(false);
+            closeScanModal();
             selectCatalogItem(item);
           }}
         />

--- a/client/src/components/SmartItemSearch.jsx
+++ b/client/src/components/SmartItemSearch.jsx
@@ -415,6 +415,7 @@ export default function SmartItemSearch({
   const [brandFilter, setBrandFilter] = useState(null);
   const [brandOptions, setBrandOptions] = useState([]);
   const searchRef = useRef(null);
+  const lastAiFillRef = useRef(null); // { query, data } from the last AI fill
 
   // Animated placeholder
   const [phIndex, setPhIndex] = useState(0);
@@ -496,7 +497,26 @@ export default function SmartItemSearch({
     setAndPersistTab("custom");
     if (!customMode) {
       setCustomMode("manual");
-      setCustomForm((f) => ({ ...f, name: prefillName || f.name }));
+      const ai = lastAiFillRef.current;
+      if (ai && ai.query === prefillName) {
+        // Re-use the last AI extraction for this query instead of dumping
+        // the raw query (often a URL) into the name field
+        setCustomForm((f) => ({
+          name: f.name || ai.data.name || "",
+          brand: f.brand || ai.data.brand || "",
+          catalogCategory: f.catalogCategory || ai.data.category || "",
+          itemType: f.itemType || ai.data.itemType || "",
+          weight: f.weight || (ai.data.weightGrams != null ? formatInput(ai.data.weightGrams) : ""),
+          description: f.description || ai.data.description || "",
+          link: f.link || ai.data.link || "",
+          imageUrl: f.imageUrl || ai.data.imageUrl || "",
+        }));
+      } else if (isUrl(prefillName)) {
+        // A URL is never a name — put it in the link field
+        setCustomForm((f) => ({ ...f, link: f.link || prefillName }));
+      } else {
+        setCustomForm((f) => ({ ...f, name: prefillName || f.name }));
+      }
     }
   };
 
@@ -690,12 +710,14 @@ export default function SmartItemSearch({
 
   // Create action — runs AI fill, then either shows a catalog match or pre-fills the custom form
   const handleCreateAction = async (queryOverride) => {
-    const inputQuery = (queryOverride !== undefined ? queryOverride : query).trim();
+    // Button handlers pass the click event — only honor string overrides
+    const inputQuery = (typeof queryOverride === "string" ? queryOverride : query).trim();
     if (!inputQuery || aiLoading) return;
     const inputIsUrl = isUrl(inputQuery);
     setAiLoading(true);
     try {
       const { data } = await api.post("/ai/fill-item", { query: inputQuery });
+      lastAiFillRef.current = { query: inputQuery, data };
 
       // The server matches the AI extraction against the catalog (with
       // progressive fallback) and returns candidates on the response.
@@ -821,18 +843,6 @@ export default function SmartItemSearch({
     catalogResults.length === 0 &&
     !showingCustomForm;
 
-  // No dead ends: when a multi-word search finds nothing in My Gear or the
-  // catalog, look it up with AI automatically — once per query
-  const autoLookupRef = useRef("");
-  useEffect(() => {
-    const q = debouncedQuery.trim();
-    if (!hasNoResults || myGearLoading) return;
-    if (isUrl(q) || q.split(/\s+/).length < 2) return;
-    if (autoLookupRef.current === q.toLowerCase()) return;
-    autoLookupRef.current = q.toLowerCase();
-    handleCreateAction(q);
-  }, [hasNoResults, debouncedQuery, myGearLoading]); // eslint-disable-line react-hooks/exhaustive-deps
-
   return (
     <div
       className="flex flex-col h-full"
@@ -887,6 +897,7 @@ export default function SmartItemSearch({
               <input
                 ref={searchRef}
                 type="text"
+                enterKeyHint="search"
                 value={query}
                 onChange={(e) => {
                   setQuery(e.target.value);
@@ -960,7 +971,7 @@ export default function SmartItemSearch({
             <div className="mt-1.5 flex items-center justify-between gap-2">
               <p className="text-xs text-primary/35 truncate">
                 {!query
-                  ? t("smartItemSearch.tabSearchHint", "Type a name · Paste a link · Snap a photo")
+                  ? t("smartItemSearch.tabSearchHint", "Type & press Enter · Paste a link · Snap a photo")
                   : " "}
               </p>
               <button

--- a/client/src/hooks/useStagedMessage.js
+++ b/client/src/hooks/useStagedMessage.js
@@ -1,0 +1,18 @@
+// client/src/hooks/useStagedMessage.js
+import { useEffect, useState } from "react";
+
+// Steps through messages on a timer and stops on the last one.
+// Resets whenever the number of messages changes (e.g. a new run starts).
+export default function useStagedMessage(messages, intervalMs = 2500) {
+  const [idx, setIdx] = useState(0);
+  const count = messages.length;
+  useEffect(() => {
+    setIdx(0);
+    if (count < 2) return undefined;
+    const timer = setInterval(() => {
+      setIdx((i) => Math.min(i + 1, count - 1));
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [count, intervalMs]);
+  return messages[Math.min(idx, count - 1)];
+}

--- a/client/src/locales/de/common.json
+++ b/client/src/locales/de/common.json
@@ -635,7 +635,6 @@
     "added": "Hinzugefügt",
     "noGearYet": "Noch keine Ausrüstung. Durchsuche den Katalog oder beschreibe einen Artikel oben.",
     "browseHint": "Durchsuche den Katalog oben oder tippe auf eine Kategorie.",
-    "aiSearching": "Suche mit KI...",
     "aiSearchingShort": "Suche…",
     "aiFill": "Mit KI ausfüllen",
     "aiTip": "Tipp: Marke, Modell & Größe angeben für bessere Ergebnisse",
@@ -695,7 +694,9 @@
       "aiFailed": "KI-Suche fehlgeschlagen. Manuell hinzufügen versuchen.",
       "nameRequired": "Name ist erforderlich",
       "invalidWeight": "Ungültiges Gewicht",
-      "previewLoadFailed": "Artikeldetails konnten nicht geladen werden."
+      "previewLoadFailed": "Artikeldetails konnten nicht geladen werden.",
+      "catalogMatch": "Im Katalog gefunden",
+      "catalogMatches": "Mögliche Treffer gefunden – wähle deinen aus"
     },
     "gearRequest": {
       "title": "Ausrüstungsartikel anfragen",
@@ -714,27 +715,28 @@
         "success": "Anfrage gesendet! Wir schauen, ob wir es hinzufügen können.",
         "failed": "Anfrage konnte nicht gesendet werden. Bitte erneut versuchen."
       }
+    },
+    "tabSearchHint": "Name eingeben & Enter · Link einfügen · Foto aufnehmen",
+    "browseToggle": "Kategorien durchstöbern",
+    "aiProgress": {
+      "reading": "Produktseite wird gelesen…",
+      "identifying": "Artikel wird identifiziert…",
+      "matching": "Abgleich mit dem Katalog…"
     }
   },
   "photoScanModal": {
     "title": "Ausrüstung scannen",
-    "subtitle": "Produktverpackung oder Produkt-Info-Screenshot",
     "takePhoto": "Foto aufnehmen",
     "uploadScreenshot": "Screenshot hochladen",
     "hint": "Funktioniert am besten mit Produktverpackungen und Screenshots",
-    "scanningBarcode": "Barcode erkannt – wird gesucht…",
     "scanningVision": "Wird per KI identifiziert…",
     "tryAgain": "Erneut versuchen",
-    "useThisItem": "Diesen Artikel verwenden",
     "errorFallback": "Scan fehlgeschlagen. Erneut versuchen oder manuell hinzufügen.",
-    "badgeBarcodePrefix": "Barcode",
-    "badgeVision": "KI-Bilderkennung",
-    "fieldName": "Name",
-    "fieldBrand": "Marke",
-    "fieldCategory": "Kategorie",
-    "fieldType": "Typ",
-    "fieldWeight": "Gewicht",
-    "fieldDesc": "Beschr."
+    "catalogMatchHeading": "Im Katalog gefunden – ist das dein Artikel?",
+    "noneOfThese": "Keiner davon",
+    "errorNotIdentified": "Kein Artikel auf dem Foto erkannt. Versuche eine schärfere Aufnahme der Verpackung oder des Etiketts.",
+    "errorRateLimited": "Zu viele Scans – warte eine Minute und versuche es erneut.",
+    "scanningMatching": "Abgleich mit dem Katalog…"
   },
   "addGearItemModal": {
     "title": "Ausrüstungs-Item(s) hinzufügen",
@@ -1456,7 +1458,10 @@
   "community": {
     "searchPlaceholder": "Alles durchsuchen…",
     "titlePlaceholder": "Titel",
-    "sort": { "new": "Neu", "top": "Top" },
+    "sort": {
+      "new": "Neu",
+      "top": "Top"
+    },
     "noPosts": "Noch keine Beiträge. Sei der Erste!",
     "loadMore": "Mehr laden",
     "postNotFound": "Beitrag nicht gefunden.",
@@ -1480,7 +1485,11 @@
       "rule6Desc": "Wir sind alle hier, weil wir die Natur lieben. Behalte die positive und einladende Energie für alle bei."
     },
     "shareSomethingWith": "Teile etwas mit {{name}}…",
-    "toolbar": { "bold": "Fett", "italic": "Kursiv", "bulletList": "Aufzählungsliste" },
+    "toolbar": {
+      "bold": "Fett",
+      "italic": "Kursiv",
+      "bulletList": "Aufzählungsliste"
+    },
     "post": {
       "createTitle": "Beitrag erstellen",
       "editTitle": "Beitrag bearbeiten",

--- a/client/src/locales/en/common.json
+++ b/client/src/locales/en/common.json
@@ -651,7 +651,6 @@
     "added": "Added",
     "noGearYet": "No gear yet. Search the catalog or describe an item above.",
     "browseHint": "Search the catalog above, or tap a category to browse.",
-    "aiSearching": "Searching with AI...",
     "aiSearchingShort": "Searching…",
     "aiFill": "Fill with AI",
     "aiTip": "Tip: include brand, model & size for better results",
@@ -711,7 +710,9 @@
       "aiFailed": "AI search failed. Try adding manually.",
       "nameRequired": "Name is required",
       "invalidWeight": "Invalid weight",
-      "previewLoadFailed": "Failed to load item details."
+      "previewLoadFailed": "Failed to load item details.",
+      "catalogMatch": "Found in catalog",
+      "catalogMatches": "Found possible matches — pick yours below"
     },
     "gearRequest": {
       "title": "Request a Gear Item",
@@ -730,27 +731,28 @@
         "success": "Request sent! We'll look into adding it.",
         "failed": "Failed to send request. Please try again."
       }
+    },
+    "tabSearchHint": "Type & press Enter · Paste a link · Snap a photo",
+    "browseToggle": "Browse categories",
+    "aiProgress": {
+      "reading": "Reading product page…",
+      "identifying": "Identifying the item…",
+      "matching": "Matching against the catalog…"
     }
   },
   "photoScanModal": {
     "title": "Scan Gear",
-    "subtitle": "Product packaging or product info screenshot",
     "takePhoto": "Take Photo",
     "uploadScreenshot": "Upload Screenshot",
     "hint": "Works best with product packaging and product info screenshots",
-    "scanningBarcode": "Barcode detected — looking up…",
     "scanningVision": "Identifying with AI…",
     "tryAgain": "Try again",
-    "useThisItem": "Use this item",
     "errorFallback": "Scan failed. Try again or add manually.",
-    "badgeBarcodePrefix": "Barcode",
-    "badgeVision": "AI Vision",
-    "fieldName": "Name",
-    "fieldBrand": "Brand",
-    "fieldCategory": "Category",
-    "fieldType": "Type",
-    "fieldWeight": "Weight",
-    "fieldDesc": "Desc"
+    "catalogMatchHeading": "Found in catalog — is this your item?",
+    "noneOfThese": "None of these",
+    "errorNotIdentified": "Couldn't identify an item in this photo. Try a clearer shot of the packaging or label.",
+    "errorRateLimited": "Too many scans — wait a minute and try again.",
+    "scanningMatching": "Matching against the catalog…"
   },
   "addGearItemModal": {
     "title": "Add gear item(s)",
@@ -1466,7 +1468,10 @@
   "community": {
     "searchPlaceholder": "Search everything…",
     "titlePlaceholder": "Title",
-    "sort": { "new": "New", "top": "Top" },
+    "sort": {
+      "new": "New",
+      "top": "Top"
+    },
     "noPosts": "No posts yet. Be the first!",
     "loadMore": "Load more",
     "postNotFound": "Post not found.",
@@ -1490,7 +1495,11 @@
       "rule6Desc": "We're all here because we love the outdoors. Keep the energy positive and welcoming for everyone."
     },
     "shareSomethingWith": "Share something with {{name}}…",
-    "toolbar": { "bold": "Bold", "italic": "Italic", "bulletList": "Bullet list" },
+    "toolbar": {
+      "bold": "Bold",
+      "italic": "Italic",
+      "bulletList": "Bullet list"
+    },
     "post": {
       "createTitle": "Create post",
       "editTitle": "Edit post",

--- a/client/src/locales/es/common.json
+++ b/client/src/locales/es/common.json
@@ -635,7 +635,6 @@
     "added": "Añadido",
     "noGearYet": "Sin equipo aún. Busca en el catálogo o describe un artículo arriba.",
     "browseHint": "Busca en el catálogo o toca una categoría para explorar.",
-    "aiSearching": "Buscando con IA...",
     "aiSearchingShort": "Buscando…",
     "aiFill": "Rellenar con IA",
     "aiTip": "Consejo: incluye marca, modelo y talla para mejores resultados",
@@ -695,7 +694,9 @@
       "aiFailed": "Búsqueda IA fallida. Intenta añadir manualmente.",
       "nameRequired": "El nombre es obligatorio",
       "invalidWeight": "Peso no válido",
-      "previewLoadFailed": "No se pudieron cargar los detalles del artículo."
+      "previewLoadFailed": "No se pudieron cargar los detalles del artículo.",
+      "catalogMatch": "Encontrado en el catálogo",
+      "catalogMatches": "Posibles coincidencias encontradas: elige la tuya abajo"
     },
     "gearRequest": {
       "title": "Solicitar un artículo de equipo",
@@ -714,27 +715,28 @@
         "success": "¡Solicitud enviada! Veremos si podemos añadirlo.",
         "failed": "No se pudo enviar la solicitud. Por favor, inténtalo de nuevo."
       }
+    },
+    "tabSearchHint": "Escribe y pulsa Enter · Pega un enlace · Haz una foto",
+    "browseToggle": "Explorar categorías",
+    "aiProgress": {
+      "reading": "Leyendo la página del producto…",
+      "identifying": "Identificando el artículo…",
+      "matching": "Comparando con el catálogo…"
     }
   },
   "photoScanModal": {
     "title": "Escanear equipo",
-    "subtitle": "Embalaje del producto o captura de información del producto",
     "takePhoto": "Tomar foto",
     "uploadScreenshot": "Subir captura",
     "hint": "Funciona mejor con embalajes de productos y capturas de pantalla",
-    "scanningBarcode": "Código detectado — buscando…",
     "scanningVision": "Identificando con IA…",
     "tryAgain": "Intentar de nuevo",
-    "useThisItem": "Usar este artículo",
     "errorFallback": "Error al escanear. Inténtalo de nuevo o añade manualmente.",
-    "badgeBarcodePrefix": "Código de barras",
-    "badgeVision": "Visión IA",
-    "fieldName": "Nombre",
-    "fieldBrand": "Marca",
-    "fieldCategory": "Categoría",
-    "fieldType": "Tipo",
-    "fieldWeight": "Peso",
-    "fieldDesc": "Desc."
+    "catalogMatchHeading": "Encontrado en el catálogo: ¿es este tu artículo?",
+    "noneOfThese": "Ninguno de estos",
+    "errorNotIdentified": "No se pudo identificar ningún artículo en la foto. Prueba con una toma más clara del embalaje o la etiqueta.",
+    "errorRateLimited": "Demasiados escaneos: espera un minuto y vuelve a intentarlo.",
+    "scanningMatching": "Comparando con el catálogo…"
   },
   "addGearItemModal": {
     "title": "Añadir artículo(s) de equipo",
@@ -1456,7 +1458,10 @@
   "community": {
     "searchPlaceholder": "Buscar en todo…",
     "titlePlaceholder": "Título",
-    "sort": { "new": "Nuevo", "top": "Top" },
+    "sort": {
+      "new": "Nuevo",
+      "top": "Top"
+    },
     "noPosts": "Aún no hay publicaciones. ¡Sé el primero!",
     "loadMore": "Cargar más",
     "postNotFound": "Publicación no encontrada.",
@@ -1480,7 +1485,11 @@
       "rule6Desc": "Todos estamos aquí porque amamos el aire libre. Mantén la energía positiva y acogedora para todos."
     },
     "shareSomethingWith": "Comparte algo con {{name}}…",
-    "toolbar": { "bold": "Negrita", "italic": "Cursiva", "bulletList": "Lista con viñetas" },
+    "toolbar": {
+      "bold": "Negrita",
+      "italic": "Cursiva",
+      "bulletList": "Lista con viñetas"
+    },
     "post": {
       "createTitle": "Crear publicación",
       "editTitle": "Editar publicación",

--- a/client/src/locales/fr/common.json
+++ b/client/src/locales/fr/common.json
@@ -642,7 +642,6 @@
     "added": "Ajouté",
     "noGearYet": "Pas encore d'équipement. Cherchez dans le catalogue ou décrivez un article.",
     "browseHint": "Cherchez dans le catalogue ou appuyez sur une catégorie.",
-    "aiSearching": "Recherche avec l'IA...",
     "aiSearchingShort": "Recherche…",
     "aiFill": "Remplir avec l'IA",
     "aiTip": "Astuce : incluez la marque, le modèle et la taille pour de meilleurs résultats",
@@ -702,7 +701,9 @@
       "aiFailed": "Recherche IA échouée. Essayez d'ajouter manuellement.",
       "nameRequired": "Le nom est requis",
       "invalidWeight": "Poids invalide",
-      "previewLoadFailed": "Impossible de charger les détails de l'article."
+      "previewLoadFailed": "Impossible de charger les détails de l'article.",
+      "catalogMatch": "Trouvé dans le catalogue",
+      "catalogMatches": "Correspondances possibles trouvées — choisissez la vôtre ci-dessous"
     },
     "gearRequest": {
       "title": "Demander un article d'équipement",
@@ -721,27 +722,28 @@
         "success": "Demande envoyée ! Nous allons voir si nous pouvons l'ajouter.",
         "failed": "Impossible d'envoyer la demande. Veuillez réessayer."
       }
+    },
+    "tabSearchHint": "Tapez un nom puis Entrée · Collez un lien · Prenez une photo",
+    "browseToggle": "Parcourir les catégories",
+    "aiProgress": {
+      "reading": "Lecture de la page produit…",
+      "identifying": "Identification de l'article…",
+      "matching": "Comparaison avec le catalogue…"
     }
   },
   "photoScanModal": {
     "title": "Scanner l'équipement",
-    "subtitle": "Emballage produit ou capture d'écran de la fiche produit",
     "takePhoto": "Prendre une photo",
     "uploadScreenshot": "Importer une capture",
     "hint": "Fonctionne mieux avec les emballages produits et les captures d'écran",
-    "scanningBarcode": "Code-barres détecté — recherche en cours…",
     "scanningVision": "Identification par IA…",
     "tryAgain": "Réessayer",
-    "useThisItem": "Utiliser cet article",
     "errorFallback": "Échec du scan. Réessayez ou ajoutez manuellement.",
-    "badgeBarcodePrefix": "Code-barres",
-    "badgeVision": "Vision IA",
-    "fieldName": "Nom",
-    "fieldBrand": "Marque",
-    "fieldCategory": "Catégorie",
-    "fieldType": "Type",
-    "fieldWeight": "Poids",
-    "fieldDesc": "Desc."
+    "catalogMatchHeading": "Trouvé dans le catalogue — est-ce votre article ?",
+    "noneOfThese": "Aucun de ceux-ci",
+    "errorNotIdentified": "Impossible d'identifier un article sur cette photo. Essayez une prise plus nette de l'emballage ou de l'étiquette.",
+    "errorRateLimited": "Trop de scans — attendez une minute et réessayez.",
+    "scanningMatching": "Comparaison avec le catalogue…"
   },
   "addGearItemModal": {
     "title": "Ajouter des articles d’équipement",
@@ -1456,7 +1458,10 @@
   "community": {
     "searchPlaceholder": "Rechercher partout…",
     "titlePlaceholder": "Titre",
-    "sort": { "new": "Nouveau", "top": "Top" },
+    "sort": {
+      "new": "Nouveau",
+      "top": "Top"
+    },
     "noPosts": "Aucun post pour l'instant. Soyez le premier !",
     "loadMore": "Charger plus",
     "postNotFound": "Post introuvable.",
@@ -1480,7 +1485,11 @@
       "rule6Desc": "Nous sommes tous ici parce que nous aimons le plein air. Garde l'énergie positive et accueillante pour tout le monde."
     },
     "shareSomethingWith": "Partagez quelque chose avec {{name}}…",
-    "toolbar": { "bold": "Gras", "italic": "Italique", "bulletList": "Liste à puces" },
+    "toolbar": {
+      "bold": "Gras",
+      "italic": "Italique",
+      "bulletList": "Liste à puces"
+    },
     "post": {
       "createTitle": "Créer un post",
       "editTitle": "Modifier le post",

--- a/client/src/locales/it/common.json
+++ b/client/src/locales/it/common.json
@@ -635,7 +635,6 @@
     "added": "Aggiunto",
     "noGearYet": "Nessun equipaggiamento. Cerca nel catalogo o descrivi un articolo sopra.",
     "browseHint": "Cerca nel catalogo o tocca una categoria per sfogliare.",
-    "aiSearching": "Ricerca con IA...",
     "aiSearchingShort": "Ricerca…",
     "aiFill": "Compila con IA",
     "aiTip": "Suggerimento: includi marca, modello e taglia per risultati migliori",
@@ -695,7 +694,9 @@
       "aiFailed": "Ricerca IA fallita. Prova ad aggiungere manualmente.",
       "nameRequired": "Il nome è obbligatorio",
       "invalidWeight": "Peso non valido",
-      "previewLoadFailed": "Impossibile caricare i dettagli dell'articolo."
+      "previewLoadFailed": "Impossibile caricare i dettagli dell'articolo.",
+      "catalogMatch": "Trovato nel catalogo",
+      "catalogMatches": "Trovate possibili corrispondenze — scegli la tua qui sotto"
     },
     "gearRequest": {
       "title": "Richiedi un articolo",
@@ -714,27 +715,28 @@
         "success": "Richiesta inviata! Verificheremo se possiamo aggiungerlo.",
         "failed": "Impossibile inviare la richiesta. Riprova."
       }
+    },
+    "tabSearchHint": "Scrivi e premi Invio · Incolla un link · Scatta una foto",
+    "browseToggle": "Sfoglia le categorie",
+    "aiProgress": {
+      "reading": "Lettura della pagina prodotto…",
+      "identifying": "Identificazione dell'articolo…",
+      "matching": "Confronto con il catalogo…"
     }
   },
   "photoScanModal": {
     "title": "Scansiona attrezzatura",
-    "subtitle": "Confezione del prodotto o screenshot della scheda prodotto",
     "takePhoto": "Scatta una foto",
     "uploadScreenshot": "Carica screenshot",
     "hint": "Funziona meglio con imballaggi di prodotti e screenshot",
-    "scanningBarcode": "Codice rilevato — ricerca in corso…",
     "scanningVision": "Identificazione tramite IA…",
     "tryAgain": "Riprova",
-    "useThisItem": "Usa questo articolo",
     "errorFallback": "Scansione fallita. Riprova o aggiungi manualmente.",
-    "badgeBarcodePrefix": "Codice a barre",
-    "badgeVision": "Visione IA",
-    "fieldName": "Nome",
-    "fieldBrand": "Marca",
-    "fieldCategory": "Categoria",
-    "fieldType": "Tipo",
-    "fieldWeight": "Peso",
-    "fieldDesc": "Descr."
+    "catalogMatchHeading": "Trovato nel catalogo — è il tuo articolo?",
+    "noneOfThese": "Nessuno di questi",
+    "errorNotIdentified": "Nessun articolo identificato nella foto. Prova con uno scatto più nitido della confezione o dell'etichetta.",
+    "errorRateLimited": "Troppe scansioni — attendi un minuto e riprova.",
+    "scanningMatching": "Confronto con il catalogo…"
   },
   "addGearItemModal": {
     "title": "Aggiungi articolo/i",
@@ -1456,7 +1458,10 @@
   "community": {
     "searchPlaceholder": "Cerca ovunque…",
     "titlePlaceholder": "Titolo",
-    "sort": { "new": "Nuovo", "top": "Top" },
+    "sort": {
+      "new": "Nuovo",
+      "top": "Top"
+    },
     "noPosts": "Nessun post ancora. Sii il primo!",
     "loadMore": "Carica altro",
     "postNotFound": "Post non trovato.",
@@ -1480,7 +1485,11 @@
       "rule6Desc": "Siamo tutti qui perché amiamo il grande aperto. Mantieni l'energia positiva e accogliente per tutti."
     },
     "shareSomethingWith": "Condividi qualcosa con {{name}}…",
-    "toolbar": { "bold": "Grassetto", "italic": "Corsivo", "bulletList": "Elenco puntato" },
+    "toolbar": {
+      "bold": "Grassetto",
+      "italic": "Corsivo",
+      "bulletList": "Elenco puntato"
+    },
     "post": {
       "createTitle": "Crea post",
       "editTitle": "Modifica post",

--- a/client/src/locales/nl/common.json
+++ b/client/src/locales/nl/common.json
@@ -635,7 +635,6 @@
     "added": "Toegevoegd",
     "noGearYet": "Nog geen uitrusting. Zoek in de catalogus of beschrijf een artikel hierboven.",
     "browseHint": "Zoek in de catalogus of tik op een categorie om te bladeren.",
-    "aiSearching": "Zoeken met AI...",
     "aiSearchingShort": "Zoeken…",
     "aiFill": "Invullen met AI",
     "aiTip": "Tip: voeg merk, model en maat toe voor betere resultaten",
@@ -695,7 +694,9 @@
       "aiFailed": "AI-zoekopdracht mislukt. Probeer handmatig toe te voegen.",
       "nameRequired": "Naam is verplicht",
       "invalidWeight": "Ongeldig gewicht",
-      "previewLoadFailed": "Artikeldetails konden niet worden geladen."
+      "previewLoadFailed": "Artikeldetails konden niet worden geladen.",
+      "catalogMatch": "Gevonden in de catalogus",
+      "catalogMatches": "Mogelijke matches gevonden — kies die van jou hieronder"
     },
     "gearRequest": {
       "title": "Uitrusting aanvragen",
@@ -714,27 +715,28 @@
         "success": "Verzoek verzonden! We kijken of we het kunnen toevoegen.",
         "failed": "Verzoek verzenden mislukt. Probeer het opnieuw."
       }
+    },
+    "tabSearchHint": "Typ & druk op Enter · Plak een link · Maak een foto",
+    "browseToggle": "Categorieën bekijken",
+    "aiProgress": {
+      "reading": "Productpagina lezen…",
+      "identifying": "Item identificeren…",
+      "matching": "Vergelijken met de catalogus…"
     }
   },
   "photoScanModal": {
     "title": "Uitrusting scannen",
-    "subtitle": "Productverpakking of productinfo-screenshot",
     "takePhoto": "Foto nemen",
     "uploadScreenshot": "Screenshot uploaden",
     "hint": "Werkt het beste met productverpakkingen en screenshots",
-    "scanningBarcode": "Barcode gedetecteerd — opzoeken…",
     "scanningVision": "Identificeren met AI…",
     "tryAgain": "Opnieuw proberen",
-    "useThisItem": "Dit artikel gebruiken",
     "errorFallback": "Scannen mislukt. Probeer opnieuw of voeg handmatig toe.",
-    "badgeBarcodePrefix": "Barcode",
-    "badgeVision": "AI-visie",
-    "fieldName": "Naam",
-    "fieldBrand": "Merk",
-    "fieldCategory": "Categorie",
-    "fieldType": "Type",
-    "fieldWeight": "Gewicht",
-    "fieldDesc": "Beschr."
+    "catalogMatchHeading": "Gevonden in de catalogus — is dit jouw item?",
+    "noneOfThese": "Geen van deze",
+    "errorNotIdentified": "Geen item herkend op deze foto. Probeer een scherpere foto van de verpakking of het etiket.",
+    "errorRateLimited": "Te veel scans — wacht een minuut en probeer het opnieuw.",
+    "scanningMatching": "Vergelijken met de catalogus…"
   },
   "addGearItemModal": {
     "title": "Uitrustingsitems toevoegen",
@@ -1456,7 +1458,10 @@
   "community": {
     "searchPlaceholder": "Overal zoeken…",
     "titlePlaceholder": "Titel",
-    "sort": { "new": "Nieuw", "top": "Top" },
+    "sort": {
+      "new": "Nieuw",
+      "top": "Top"
+    },
     "noPosts": "Nog geen berichten. Wees de eerste!",
     "loadMore": "Meer laden",
     "postNotFound": "Bericht niet gevonden.",
@@ -1480,7 +1485,11 @@
       "rule6Desc": "We zijn hier allemaal omdat we van de buitenlucht houden. Houd de energie positief en verwelkomend voor iedereen."
     },
     "shareSomethingWith": "Deel iets met {{name}}…",
-    "toolbar": { "bold": "Vet", "italic": "Cursief", "bulletList": "Ongeordende lijst" },
+    "toolbar": {
+      "bold": "Vet",
+      "italic": "Cursief",
+      "bulletList": "Ongeordende lijst"
+    },
     "post": {
       "createTitle": "Bericht plaatsen",
       "editTitle": "Bericht bewerken",

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -392,7 +392,7 @@ router.post("/scan-item", async (req, res) => {
       ? ""
       : `\nWrite the \`description\` field in ${languageName}. All other fields stay in standard format.`;
 
-  const systemPrompt = `You are an expert outdoor gear product database with detailed knowledge of hiking, backpacking, camping, and outdoor gear.
+  const systemPrompt = `You are an expert product database with deep knowledge of outdoor gear (hiking, backpacking, camping) as well as general consumer products. Items do not need to be outdoor gear — identify whatever product is shown.
 
 Given product information (text or image), return a JSON object with these exact fields:
 - name: model name without brand prefix (string, required)
@@ -411,7 +411,7 @@ DESCRIPTION rules:
 • Never write generic phrases like "designed for outdoor adventures"${descLangInstruction}
 
 CRITICAL: Your response must be ONLY a valid JSON object — no text before or after, no apology, no explanation.
-If this is NOT outdoor gear or you cannot identify it, return exactly: {"name":null}`;
+If you cannot identify the item at all, return exactly: {"name":null}`;
 
   try {
     const base64Match = image.match(/^data:([^;]+);base64,(.+)$/s);
@@ -427,7 +427,7 @@ If this is NOT outdoor gear or you cannot identify it, return exactly: {"name":n
       role: "user",
       content: [
         { type: "image", source: { type: "base64", media_type: mediaType, data: base64Data } },
-        { type: "text", text: "Identify this outdoor gear item. Look for visible brand logos, model numbers, tags, labels, or distinguishing physical features. Return the JSON as specified." },
+        { type: "text", text: "Identify this product. Look for visible brand logos, model numbers, tags, labels, or distinguishing physical features. Return the JSON as specified." },
       ],
     }];
 
@@ -446,12 +446,12 @@ If this is NOT outdoor gear or you cannot identify it, return exactly: {"name":n
     try {
       raw = JSON.parse(cleaned);
     } catch {
-      return res.status(422).json({ error: "Item not recognized as outdoor gear" });
+      return res.status(422).json({ error: "Could not identify an item in this photo" });
     }
 
     const resultName = typeof raw.name === "string" ? raw.name.trim() : null;
     if (!resultName) {
-      return res.status(422).json({ error: "Item not recognized as outdoor gear" });
+      return res.status(422).json({ error: "Could not identify an item in this photo" });
     }
 
     const resultBrand = typeof raw.brand === "string" ? raw.brand.trim() || null : null;

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -4,6 +4,7 @@ const rateLimit = require("express-rate-limit");
 const router = express.Router();
 const { getClient } = require("../services/anthropicService");
 const { findCatalogMatches } = require("../services/catalogMatch");
+const AffiliateProduct = require("../models/affiliateProduct");
 const User = require("../models/user");
 
 // Per-user limit — every request here costs Anthropic tokens
@@ -364,6 +365,7 @@ DESCRIPTION — be specific, never generic:
 • Tents/shelters: capacity, pole material, freestanding or not
 • Footwear: waterproofing, boot height
 • Cooking: fuel type, boil time
+Only state specs you are confident about — omit a spec entirely rather than guess (e.g. never claim a tent is freestanding or name pole materials unless certain).
 Never write sentences like "designed for outdoor adventures" or "perfect for hiking".${descLangInstruction}`;
 
   const trimmedQuery = query.trim();
@@ -377,6 +379,21 @@ Never write sentences like "designed for outdoor adventures" or "perfect for hik
       const isUrl = /^https?:\/\//i.test(trimmedQuery);
       let userMessage = trimmedQuery;
       let scrapedImageUrl = null;
+      let scrapedWeight = null;
+      let affiliateImage = null;
+
+      // Bare merchant item number (e.g. Decathlon "8975262") — resolve it
+      // through the affiliate feed so the AI gets a real product name
+      if (!isUrl && /^\d{5,}$/.test(trimmedQuery)) {
+        const affiliate = await AffiliateProduct.findOne({ merchantProductId: trimmedQuery }).lean();
+        if (affiliate) {
+          userMessage = `Product: ${[affiliate.brand, affiliate.name].filter(Boolean).join(" ")}`;
+          if (affiliate.description) {
+            userMessage += `\n\n${String(affiliate.description).slice(0, 400)}`;
+          }
+          affiliateImage = affiliate.imageUrl || affiliate.imageUrls?.[0] || null;
+        }
+      }
 
       if (isUrl) {
         // Amazon mobile/sharing redirect URLs contain no product info — fail early with a clear message
@@ -393,11 +410,12 @@ Never write sentences like "designed for outdoor adventures" or "perfect for hik
           userMessage = `URL: ${trimmedQuery}\n\n${formatted}`;
         }
         if (pageData?.imageUrl) scrapedImageUrl = pageData.imageUrl;
+        if (pageData?.weightGrams) scrapedWeight = pageData.weightGrams;
         // If fetch failed, fall through with just the URL — Claude will still parse the slug
       }
 
       const message = await anthropic.messages.create({
-        model: "claude-haiku-4-5",
+        model: "claude-sonnet-4-6",
         max_tokens: 1000,
         system: systemPrompt,
         output_config: ITEM_OUTPUT_CONFIG,
@@ -416,12 +434,12 @@ Never write sentences like "designed for outdoor adventures" or "perfect for hik
         name: resultName,
         brand: resultBrand,
         itemType: typeof raw.itemType === "string" ? raw.itemType.trim() || null : null,
-        weightGrams: null,
+        weightGrams: scrapedWeight ?? null, // scraped spec only — the model never guesses weights
         category: CATALOG_CATEGORIES.includes(raw.category) ? raw.category : null,
         description:
           typeof raw.description === "string" ? raw.description.trim() || null : null,
         link: isUrl ? trimmedQuery : null,
-        imageUrl: await validateImageUrl(scrapedImageUrl),
+        imageUrl: await validateImageUrl(scrapedImageUrl || affiliateImage),
       };
       fillCacheSet(cacheKey, result);
     }

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -1,8 +1,22 @@
 // server/src/routes/ai.js
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 const router = express.Router();
 const { getClient } = require("../services/anthropicService");
+const { findCatalogMatches } = require("../services/catalogMatch");
 const User = require("../models/user");
+
+// Per-user limit — every request here costs Anthropic tokens
+router.use(
+  rateLimit({
+    windowMs: 60 * 1000,
+    limit: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => String(req.userId),
+    message: { error: "rate_limited", message: "Too many AI requests — try again in a minute." },
+  }),
+);
 
 const CATALOG_CATEGORIES = [
   "Accessories & Tools",
@@ -30,27 +44,82 @@ const LANGUAGE_NAMES = {
   es: "Spanish",
 };
 
-// ── Google Image Search ────────────────────────────────────────────────────────
+// ── Structured AI output ───────────────────────────────────────────────────────
+// JSON schema enforced via output_config.format — the API guarantees the
+// response parses against this, so no fence-stripping or parse retries needed.
 
-async function fetchGoogleImage(brand, name) {
-  const apiKey = process.env.GOOGLE_SEARCH_API_KEY;
-  const cx = process.env.GOOGLE_SEARCH_CX;
-  if (!apiKey || !cx) return null;
+const nullable = (type) => ({ anyOf: [{ type }, { type: "null" }] });
 
-  const q = [brand, name].filter(Boolean).join(" ");
+const ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    name: nullable("string"),
+    brand: nullable("string"),
+    itemType: nullable("string"),
+    weightGrams: nullable("integer"),
+    category: { anyOf: [{ type: "string", enum: CATALOG_CATEGORIES }, { type: "null" }] },
+    description: nullable("string"),
+  },
+  required: ["name", "brand", "itemType", "weightGrams", "category", "description"],
+  additionalProperties: false,
+};
+
+const ITEM_OUTPUT_CONFIG = { format: { type: "json_schema", schema: ITEM_SCHEMA } };
+
+function parseStructuredItem(message) {
+  const text = message.content?.find((b) => b.type === "text")?.text;
+  if (!text) return null;
   try {
-    const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${cx}&q=${encodeURIComponent(q)}&searchType=image&num=1&imgSize=large&imgType=photo`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
-    const data = await res.json();
-    if (!res.ok) {
-      console.warn("[Google] Image search failed:", data?.error?.message);
-      return null;
-    }
-    return cleanImageUrl(data.items?.[0]?.link ?? null);
-  } catch (err) {
-    console.warn("[Google] Image search error:", err.message);
+    return JSON.parse(text);
+  } catch {
+    return null; // only reachable on a safety refusal — schema is enforced otherwise
+  }
+}
+
+// ── Image URL validation ───────────────────────────────────────────────────────
+// Never hand the client a dead image link. Hard failures (404/410/403) drop the
+// URL; timeouts and HEAD-unsupported responses keep it — slow CDNs aren't dead.
+
+async function validateImageUrl(url) {
+  if (!url) return null;
+  try {
+    const res = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      signal: AbortSignal.timeout(2500),
+    });
+    return res.ok || res.status === 405 ? url : null;
+  } catch {
+    return url;
+  }
+}
+
+// ── fill-item result cache ─────────────────────────────────────────────────────
+// Popular queries ("Nemo Tensor", "Xmid 2") repeat across users; cache the AI
+// extraction (keyed by language + normalized query). Catalog matches are NOT
+// cached — they're recomputed per request so new catalog items show up.
+
+const FILL_CACHE_MAX = 500;
+const FILL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const fillCache = new Map();
+
+function fillCacheGet(key) {
+  const entry = fillCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.at > FILL_CACHE_TTL_MS) {
+    fillCache.delete(key);
     return null;
   }
+  fillCache.delete(key); // LRU: re-insert on read
+  fillCache.set(key, entry);
+  return entry.value;
+}
+
+function fillCacheSet(key, value) {
+  if (fillCache.size >= FILL_CACHE_MAX) {
+    fillCache.delete(fillCache.keys().next().value);
+  }
+  fillCache.set(key, { at: Date.now(), value });
 }
 
 // ── URL scraping ───────────────────────────────────────────────────────────────
@@ -281,7 +350,7 @@ router.post("/fill-item", async (req, res) => {
   const systemPrompt = `You are an expert outdoor gear product database. You have detailed knowledge of hiking, backpacking, camping, and outdoor gear including weights, specs, and technical details.
 
 Given a product name query, return a JSON object with these exact fields:
-- name: model name without brand (string, required). Include size/variant only if explicitly specified in the query
+- name: model name without brand and without generic product-type words like "Backpack", "Tent", "Stove" — those belong in itemType (string, required). Include size/variant only if explicitly specified in the query
 - brand: manufacturer name with correct capitalization (string or null)
 - itemType: specific product type in plain English, e.g. "Canister Stove", "Frameless Backpack", "Inflatable Sleeping Pad" (string or null)
 - weightGrams: always null — do not guess weights, they change between model years
@@ -295,77 +364,79 @@ DESCRIPTION — be specific, never generic:
 • Tents/shelters: capacity, pole material, freestanding or not
 • Footwear: waterproofing, boot height
 • Cooking: fuel type, boil time
-Never write sentences like "designed for outdoor adventures" or "perfect for hiking".${descLangInstruction}
+Never write sentences like "designed for outdoor adventures" or "perfect for hiking".${descLangInstruction}`;
 
-Return only valid JSON. No explanation, no markdown.`;
+  const trimmedQuery = query.trim();
+  const cacheKey = `${userLang}:${trimmedQuery.toLowerCase()}`;
 
   try {
-    // If query is a URL, fetch real product data first
-    const isUrl = /^https?:\/\//i.test(query.trim());
-    let userMessage = query.trim();
-    let scrapedImageUrl = null;
+    let result = fillCacheGet(cacheKey);
 
-    if (isUrl) {
-      // Amazon mobile/sharing redirect URLs contain no product info — fail early with a clear message
-      if (/amazon\.[a-z.]+\/hz\/mobile\/mission/i.test(query.trim())) {
-        return res.status(400).json({
-          error: "amazon_redirect",
-          message: "This is an Amazon sharing link, not a product page. Please open the product on Amazon and copy the URL from your browser's address bar.",
-        });
+    if (!result) {
+      // If query is a URL, fetch real product data first
+      const isUrl = /^https?:\/\//i.test(trimmedQuery);
+      let userMessage = trimmedQuery;
+      let scrapedImageUrl = null;
+
+      if (isUrl) {
+        // Amazon mobile/sharing redirect URLs contain no product info — fail early with a clear message
+        if (/amazon\.[a-z.]+\/hz\/mobile\/mission/i.test(trimmedQuery)) {
+          return res.status(400).json({
+            error: "amazon_redirect",
+            message: "This is an Amazon sharing link, not a product page. Please open the product on Amazon and copy the URL from your browser's address bar.",
+          });
+        }
+
+        const pageData = await fetchProductPage(trimmedQuery);
+        const formatted = formatPageDataForPrompt(pageData);
+        if (formatted) {
+          userMessage = `URL: ${trimmedQuery}\n\n${formatted}`;
+        }
+        if (pageData?.imageUrl) scrapedImageUrl = pageData.imageUrl;
+        // If fetch failed, fall through with just the URL — Claude will still parse the slug
       }
 
-      const pageData = await fetchProductPage(query.trim());
-      const formatted = formatPageDataForPrompt(pageData);
-      if (formatted) {
-        userMessage = `URL: ${query.trim()}\n\n${formatted}`;
+      const message = await anthropic.messages.create({
+        model: "claude-haiku-4-5",
+        max_tokens: 1000,
+        system: systemPrompt,
+        output_config: ITEM_OUTPUT_CONFIG,
+        messages: [{ role: "user", content: userMessage }],
+      });
+
+      const raw = parseStructuredItem(message);
+      if (!raw) {
+        return res.status(500).json({ error: "ai_failed", message: "AI request failed" });
       }
-      if (pageData?.imageUrl) scrapedImageUrl = pageData.imageUrl;
-      // If fetch failed, fall through with just the URL — Claude will still parse the slug
+
+      const resultName = (typeof raw.name === "string" ? raw.name.trim() : null) || trimmedQuery;
+      const resultBrand = typeof raw.brand === "string" ? raw.brand.trim() || null : null;
+
+      result = {
+        name: resultName,
+        brand: resultBrand,
+        itemType: typeof raw.itemType === "string" ? raw.itemType.trim() || null : null,
+        weightGrams: null,
+        category: CATALOG_CATEGORIES.includes(raw.category) ? raw.category : null,
+        description:
+          typeof raw.description === "string" ? raw.description.trim() || null : null,
+        link: isUrl ? trimmedQuery : null,
+        imageUrl: await validateImageUrl(scrapedImageUrl),
+      };
+      fillCacheSet(cacheKey, result);
     }
 
-    const message = await anthropic.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 300,
-      system: systemPrompt,
-      messages: [{ role: "user", content: userMessage }],
-    });
-
-    const text = message.content[0]?.text?.trim();
-    if (!text) return res.status(500).json({ error: "Empty AI response" });
-
-    const cleaned = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
-    let raw;
-    try {
-      raw = JSON.parse(cleaned);
-    } catch {
-      return res.status(500).json({ error: "Failed to parse AI response" });
+    // Catalog matches are computed fresh (never cached) so new items show up.
+    // Image fallback: scraped og:image → top catalog match's curated image.
+    const catalogMatches = await findCatalogMatches(result);
+    if (!result.imageUrl && catalogMatches[0]?.imageUrls?.[0]) {
+      result = { ...result, imageUrl: catalogMatches[0].imageUrls[0] };
     }
 
-    const resultName = (typeof raw.name === "string" ? raw.name.trim() : null) || query.trim();
-    const resultBrand = typeof raw.brand === "string" ? raw.brand.trim() || null : null;
-
-    // Try to get product image: scraped URL → Google Image Search
-    let imageUrl = scrapedImageUrl;
-    if (!imageUrl) {
-      imageUrl = await fetchGoogleImage(resultBrand, resultName);
-    }
-
-    const result = {
-      name: resultName,
-      brand: resultBrand,
-      itemType: typeof raw.itemType === "string" ? raw.itemType.trim() || null : null,
-      weightGrams: null,
-      category: CATALOG_CATEGORIES.includes(raw.category) ? raw.category : null,
-      description:
-        typeof raw.description === "string" ? raw.description.trim() || null : null,
-      link: isUrl ? query.trim() : null,
-      imageUrl,
-    };
-
-    res.json(result);
+    res.json({ ...result, catalogMatches });
   } catch (err) {
     console.error("[Anthropic] fill-item failed:", err.message);
-    res.status(500).json({ error: "AI request failed" });
+    res.status(500).json({ error: "ai_failed", message: "AI request failed" });
   }
 });
 
@@ -395,7 +466,7 @@ router.post("/scan-item", async (req, res) => {
   const systemPrompt = `You are an expert product database with deep knowledge of outdoor gear (hiking, backpacking, camping) as well as general consumer products. Items do not need to be outdoor gear — identify whatever product is shown.
 
 Given product information (text or image), return a JSON object with these exact fields:
-- name: model name without brand prefix (string, required)
+- name: model name without brand prefix and without generic product-type words like "Backpack", "Tent", "Stove" — those belong in itemType (string, required)
 - brand: manufacturer name with correct capitalization (string or null)
 - itemType: specific product type in plain English, e.g. "Canister Stove", "Frameless Backpack", "Inflatable Sleeping Pad" (string or null)
 - weightGrams: weight in grams as an integer if clearly known, otherwise null — do not guess
@@ -410,18 +481,17 @@ DESCRIPTION rules:
 • Stoves: fuel type, boil time if known
 • Never write generic phrases like "designed for outdoor adventures"${descLangInstruction}
 
-CRITICAL: Your response must be ONLY a valid JSON object — no text before or after, no apology, no explanation.
-If you cannot identify the item at all, return exactly: {"name":null}`;
+If you cannot identify the item at all, set name to null.`;
 
   try {
     const base64Match = image.match(/^data:([^;]+);base64,(.+)$/s);
     if (!base64Match) {
-      return res.status(400).json({ error: "Invalid image format" });
+      return res.status(400).json({ error: "invalid_image", message: "Invalid image format" });
     }
     const mediaType = base64Match[1];
     const base64Data = base64Match[2];
     if (!["image/jpeg", "image/png", "image/webp", "image/gif"].includes(mediaType)) {
-      return res.status(400).json({ error: "Unsupported image type. Use JPEG, PNG, or WebP." });
+      return res.status(400).json({ error: "unsupported_image", message: "Unsupported image type. Use JPEG, PNG, or WebP." });
     }
     const messages = [{
       role: "user",
@@ -431,46 +501,53 @@ If you cannot identify the item at all, return exactly: {"name":null}`;
       ],
     }];
 
-    const message = await anthropic.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 400,
-      system: systemPrompt,
-      messages,
-    });
-
-    const text = message.content[0]?.text?.trim();
-    if (!text) return res.status(500).json({ error: "Empty AI response" });
-
-    const cleaned = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
-    let raw;
-    try {
-      raw = JSON.parse(cleaned);
-    } catch {
-      return res.status(422).json({ error: "Could not identify an item in this photo" });
+    // Escalation ladder: Haiku handles most scans cheaply; when it can't
+    // identify the item, retry once with Sonnet before giving up.
+    let raw = null;
+    for (const model of ["claude-haiku-4-5", "claude-sonnet-4-6"]) {
+      const message = await anthropic.messages.create({
+        model,
+        max_tokens: 1000,
+        system: systemPrompt,
+        output_config: ITEM_OUTPUT_CONFIG,
+        messages,
+      });
+      const parsed = parseStructuredItem(message);
+      if (parsed && typeof parsed.name === "string" && parsed.name.trim()) {
+        raw = parsed;
+        break;
+      }
     }
 
-    const resultName = typeof raw.name === "string" ? raw.name.trim() : null;
-    if (!resultName) {
-      return res.status(422).json({ error: "Could not identify an item in this photo" });
+    if (!raw) {
+      return res.status(422).json({
+        error: "not_identified",
+        message: "Could not identify an item in this photo",
+      });
     }
 
-    const resultBrand = typeof raw.brand === "string" ? raw.brand.trim() || null : null;
-
-    const imageUrl = await fetchGoogleImage(resultBrand, resultName);
-
-    res.json({
-      name: resultName,
-      brand: resultBrand,
+    const result = {
+      name: raw.name.trim(),
+      brand: typeof raw.brand === "string" ? raw.brand.trim() || null : null,
       itemType: typeof raw.itemType === "string" ? raw.itemType.trim() || null : null,
       weightGrams: typeof raw.weightGrams === "number" ? Math.round(raw.weightGrams) : null,
       category: CATALOG_CATEGORIES.includes(raw.category) ? raw.category : null,
       description: typeof raw.description === "string" ? raw.description.trim() || null : null,
       link: null,
-      imageUrl,
-    });
+      imageUrl: null,
+    };
+
+    // Image: top catalog match's curated photo (the client also has the user's
+    // own photo as a fallback via photoUrl).
+    const catalogMatches = await findCatalogMatches(result);
+    if (catalogMatches[0]?.imageUrls?.[0]) {
+      result.imageUrl = catalogMatches[0].imageUrls[0];
+    }
+
+    res.json({ ...result, catalogMatches });
   } catch (err) {
     console.error("[Anthropic] scan-item failed:", err.message);
-    res.status(500).json({ error: "AI request failed" });
+    res.status(500).json({ error: "ai_failed", message: "AI request failed" });
   }
 });
 

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -171,7 +171,7 @@ async function tryShopifyJson(url, signal) {
     if (!p) return null;
 
     // Collect unique variant titles + weights
-    const variants = (p.variants || [])
+    const allVariants = (p.variants || [])
       .slice(0, 8)
       .map((v) => {
         const wg =
@@ -179,14 +179,17 @@ async function tryShopifyJson(url, signal) {
             ? toGrams(v.weight, v.weight_unit)
             : null;
         return { title: v.title, weightGrams: wg };
-      })
-      .filter((v) => v.title !== "Default Title");
+      });
+    const variants = allVariants.filter((v) => v.title !== "Default Title");
 
     return {
       source: "shopify",
       title: p.title,
       vendor: p.vendor,
       description: stripHtml(p.body_html || "").slice(0, 600),
+      // Single-variant products: the variant weight IS the product weight
+      // (often shipping weight — a page spec-table weight overrides it later)
+      weightGrams: allVariants.length === 1 ? allVariants[0].weightGrams : undefined,
       variants,
     };
   } catch {
@@ -206,6 +209,18 @@ function extractSpecsFromText(text) {
   // Any "weight" label near a gram value
   const anyW = text.match(/\bweight[^\d]{0,60}(\d+)\s*g\b/i);
   if (anyW) return { weightGrams: parseInt(anyW[1], 10) };
+
+  // Metric: "Weight: 1.13 kg"
+  const kg = text.match(/\bweight[^\d]{0,60}(\d+(?:\.\d+)?)\s*kg\b/i);
+  if (kg) return { weightGrams: Math.round(parseFloat(kg[1]) * 1000) };
+
+  // Imperial: "Weight: 2 lb 7.5 oz" (oz part optional)
+  const lboz = text.match(/\bweight[^\d]{0,60}(\d+)\s*lbs?\b(?:[^\d]{0,10}(\d+(?:\.\d+)?)\s*oz)?/i);
+  if (lboz) {
+    const grams =
+      parseFloat(lboz[1]) * 453.592 + (lboz[2] ? parseFloat(lboz[2]) * 28.3495 : 0);
+    return { weightGrams: Math.round(grams) };
+  }
 
   return {};
 }
@@ -354,7 +369,7 @@ Given a product name query, return a JSON object with these exact fields:
 - name: model name without brand and without generic product-type words like "Backpack", "Tent", "Stove" — those belong in itemType (string, required). Include size/variant only if explicitly specified in the query
 - brand: manufacturer name with correct capitalization (string or null)
 - itemType: specific product type in plain English, e.g. "Canister Stove", "Frameless Backpack", "Inflatable Sleeping Pad" (string or null)
-- weightGrams: always null — do not guess weights, they change between model years
+- weightGrams: integer grams ONLY if a weight appears in the product data provided above (choose the standard/Regular variant when several are listed); otherwise null — never use weights from memory, they change between model years
 - category: exactly one of these values or null: ${CATALOG_CATEGORIES.join(", ")}
 - description: a specific, technical 1–2 sentence description mentioning key specs for the product type (string or null)
 
@@ -434,7 +449,10 @@ Never write sentences like "designed for outdoor adventures" or "perfect for hik
         name: resultName,
         brand: resultBrand,
         itemType: typeof raw.itemType === "string" ? raw.itemType.trim() || null : null,
-        weightGrams: scrapedWeight ?? null, // scraped spec only — the model never guesses weights
+        // Scraped weight wins; else the weight the model copied from page data
+        weightGrams:
+          scrapedWeight ??
+          (typeof raw.weightGrams === "number" ? Math.round(raw.weightGrams) : null),
         category: CATALOG_CATEGORIES.includes(raw.category) ? raw.category : null,
         description:
           typeof raw.description === "string" ? raw.description.trim() || null : null,

--- a/server/src/routes/catalog.js
+++ b/server/src/routes/catalog.js
@@ -9,19 +9,9 @@ const auth = require("../middleware/auth");
 const User = require("../models/user");
 const AffiliateProduct = require("../models/affiliateProduct");
 
+const { tokenRegex } = require("../utils/tokenRegex");
+
 const router = express.Router();
-
-function escapeRegex(s) {
-  return String(s || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-// Build a regex for a search token that tolerates missing hyphens.
-// "xmid" and "x-mid" both produce /x[-]?m[-]?i[-]?d/i so they match "X-Mid".
-function tokenRegex(token) {
-  const normalized = token.replace(/[-\s]+/g, "");
-  const pattern = normalized.split("").map((c) => escapeRegex(c)).join("[-]?");
-  return new RegExp(pattern, "i");
-}
 
 // Small normalization helper (server-side)
 function normalizeRegion(region) {

--- a/server/src/services/catalogMatch.js
+++ b/server/src/services/catalogMatch.js
@@ -1,0 +1,77 @@
+// server/src/services/catalogMatch.js
+// Match AI-extracted item fields ({name, brand, itemType}) against the catalog.
+//
+// The catalog search requires every token to match some field, but AI
+// extraction often appends generic words ("Exos 58 Backpack") that aren't in
+// any catalog field and silently produce zero matches. This service retries
+// progressively looser queries until something hits:
+//   1. all name + brand tokens (deduped)
+//   2. minus tokens that appear in itemType ("Backpack", "Stove", ...)
+//   3. minus trailing tokens, one at a time, down to two tokens
+const CatalogItem = require("../models/catalogItem");
+const { tokenRegex } = require("../utils/tokenRegex");
+
+const MATCH_FIELDS =
+  "name brand category subcategory itemType description weightGrams imageUrls tags";
+const MAX_ATTEMPTS = 4;
+
+function tokenize(str) {
+  return String(str || "").replace(/\s+/g, " ").trim().split(" ").filter(Boolean);
+}
+
+function buildAttempts({ name, brand, itemType }) {
+  const seen = new Set();
+  const base = [];
+  for (const tok of [...tokenize(name), ...tokenize(brand)]) {
+    const key = tok.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      base.push(tok);
+    }
+  }
+  if (base.length === 0) return [];
+
+  const attempts = [base];
+  const typeWords = new Set(tokenize(itemType).map((t) => t.toLowerCase()));
+  if (typeWords.size > 0) {
+    const stripped = base.filter((t) => !typeWords.has(t.toLowerCase()));
+    if (stripped.length > 0 && stripped.length < base.length) attempts.push(stripped);
+  }
+  let current = attempts[attempts.length - 1];
+  while (current.length > 2 && attempts.length < MAX_ATTEMPTS) {
+    current = current.slice(0, -1);
+    attempts.push(current);
+  }
+  return attempts.slice(0, MAX_ATTEMPTS);
+}
+
+function tokenQuery(tokens) {
+  const fields = (regex) => [
+    { name: regex },
+    { brand: regex },
+    { tags: regex },
+    { subcategory: regex },
+  ];
+  if (tokens.length === 1) return { $or: fields(tokenRegex(tokens[0])) };
+  return { $and: tokens.map((t) => ({ $or: fields(tokenRegex(t)) })) };
+}
+
+// Best-effort: returns [] on any failure rather than throwing.
+async function findCatalogMatches(extracted, limit = 4) {
+  try {
+    for (const tokens of buildAttempts(extracted || {})) {
+      const items = await CatalogItem.find({ isActive: true, ...tokenQuery(tokens) })
+        .collation({ locale: "en", strength: 2 })
+        .sort({ brand: 1, name: 1 })
+        .limit(limit)
+        .select(MATCH_FIELDS)
+        .lean();
+      if (items.length > 0) return items;
+    }
+  } catch (err) {
+    console.warn("[catalogMatch] lookup failed:", err.message);
+  }
+  return [];
+}
+
+module.exports = { findCatalogMatches };

--- a/server/src/utils/tokenRegex.js
+++ b/server/src/utils/tokenRegex.js
@@ -1,0 +1,16 @@
+// server/src/utils/tokenRegex.js
+// Shared search-token helpers for catalog text matching.
+
+function escapeRegex(s) {
+  return String(s || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Build a regex for a search token that tolerates missing hyphens.
+// "xmid" and "x-mid" both produce /x[-]?m[-]?i[-]?d/i so they match "X-Mid".
+function tokenRegex(token) {
+  const normalized = token.replace(/[-\s]+/g, "");
+  const pattern = normalized.split("").map((c) => escapeRegex(c)).join("[-]?");
+  return new RegExp(pattern, "i");
+}
+
+module.exports = { escapeRegex, tokenRegex };


### PR DESCRIPTION
After an AI photo scan, search the catalog with the extracted name and brand (overlapped with the Cloudinary upload). Matches are shown for one-tap import; no match goes straight to the pre-filled custom form, with a "None of these" escape hatch in between.

- Extract shared selectCatalogItem helper so scan and AI-fill flows select exclusively, clear the custom form, and switch to Import
- Render the From Catalog section when results exist even without an active search query, so injected scan matches are visible
- Allow non-outdoor products in /ai/scan-item instead of rejecting them